### PR TITLE
feat: add tab-completion for slash commands

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,0 +1,240 @@
+/**
+ * Command Auto-Completion
+ *
+ * Provides tab-completion for slash commands in the REPL.
+ * Supports:
+ * - Command name completion (/br<TAB> -> /branch)
+ * - Subcommand completion (/branch cr<TAB> -> /branch create)
+ * - Static argument completion (/models an<TAB> -> /models anthropic)
+ * - Flag completion (/models --<TAB> -> /models --local)
+ * - Dynamic completion (git branches, session names)
+ */
+
+import { execSync } from 'child_process';
+import { readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { getAllCommands } from './commands/index.js';
+
+/**
+ * Pre-defined subcommands for commands that support them.
+ */
+const COMMAND_SUBCOMMANDS: Record<string, string[]> = {
+  branch: ['list', 'create', 'switch', 'delete', 'rename'],
+  stash: ['save', 'list', 'pop', 'apply', 'drop', 'clear'],
+  undo: ['commits', 'staged', 'file'],
+  config: ['init', 'show', 'example'],
+  modelmap: ['init', 'show', 'example'],
+  usage: ['session', 'today', 'week', 'month', 'all', 'recent', 'reset', 'clear'],
+  sessions: ['info', 'delete', 'clear'],
+  rag: ['rebuild', 'update', 'stats', 'search', 'clear'],
+  index: ['rebuild', 'update', 'stats', 'search', 'clear'],
+  symbols: ['rebuild', 'update', 'stats', 'search', 'clear'],
+  filehistory: ['clear'],
+  plugins: ['info', 'dir'],
+  profile: ['set'],
+  import: ['list', 'search', 'all'],
+};
+
+/**
+ * Static arguments for commands.
+ */
+const COMMAND_STATIC_ARGS: Record<string, string[]> = {
+  models: ['anthropic', 'openai', 'ollama'],
+  switch: ['anthropic', 'openai', 'ollama'],
+  commit: ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'chore'],
+  new: ['component', 'hook', 'page', 'api', 'service', 'util', 'test'],
+};
+
+/**
+ * Command-specific flags.
+ */
+const COMMAND_FLAGS: Record<string, string[]> = {
+  models: ['--local'],
+  symbols: ['--deep', '--jobs'],
+  pipeline: ['--provider', '--all', '--v2', '--v3', '--v4', '--triage', '--triage-only', '--concurrency'],
+};
+
+/**
+ * Commands that support git branch completion.
+ */
+const GIT_BRANCH_COMMANDS = ['branch', 'merge', 'rebase', 'checkout', 'diff'];
+
+/**
+ * Commands that support session name completion.
+ */
+const SESSION_COMMANDS = ['load', 'sessions'];
+
+/**
+ * Get git branch names synchronously.
+ * Returns empty array if not in a git repo or on error.
+ */
+function getGitBranches(): string[] {
+  try {
+    const output = execSync('git branch --format="%(refname:short)"', {
+      encoding: 'utf-8',
+      timeout: 1000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return output
+      .split('\n')
+      .map(b => b.trim())
+      .filter(b => b.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get session names from ~/.codi/sessions/.
+ */
+function getSessionNames(): string[] {
+  const sessionsDir = join(homedir(), '.codi', 'sessions');
+  if (!existsSync(sessionsDir)) return [];
+  try {
+    return readdirSync(sessionsDir)
+      .filter(f => f.endsWith('.json'))
+      .map(f => f.replace('.json', ''));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Create a completer function for readline.
+ * The completer is called on TAB press and returns matching completions.
+ *
+ * @returns A completer function compatible with readline's completer option
+ */
+export function createCompleter(): (line: string) => [string[], string] {
+  // Cache command names at creation time for performance
+  const allCommands = getAllCommands();
+  const commandNames: string[] = [];
+
+  for (const cmd of allCommands) {
+    commandNames.push(cmd.name);
+    if (cmd.aliases) {
+      commandNames.push(...cmd.aliases);
+    }
+  }
+
+  // Sort for consistent ordering
+  commandNames.sort();
+
+  return (line: string): [string[], string] => {
+    // Only complete slash commands
+    if (!line.startsWith('/')) {
+      return [[], line];
+    }
+
+    const trimmed = line.slice(1); // Remove leading /
+    const parts = trimmed.split(/\s+/);
+    const isTypingArg = trimmed.endsWith(' ') || parts.length > 1;
+
+    // Complete command names
+    if (!isTypingArg) {
+      const partial = parts[0].toLowerCase();
+      const matches = commandNames
+        .filter(name => name.startsWith(partial))
+        .map(name => `/${name} `);
+      return [matches.length > 0 ? matches : [], line];
+    }
+
+    // Complete arguments for the command
+    const cmdName = parts[0].toLowerCase();
+    const argParts = parts.slice(1).filter(p => p.length > 0); // Filter out empty strings
+    const currentArg = trimmed.endsWith(' ') ? '' : (argParts[argParts.length - 1] || '');
+    const completedArgs = trimmed.endsWith(' ') ? argParts : argParts.slice(0, -1);
+
+    // Collect all possible completions
+    const completions: string[] = [];
+
+    // Add subcommands (only for first argument position)
+    if (completedArgs.length === 0) {
+      const subcommands = COMMAND_SUBCOMMANDS[cmdName] || [];
+      completions.push(...subcommands.filter(s => s.startsWith(currentArg)));
+    }
+
+    // Add static args
+    const staticArgs = COMMAND_STATIC_ARGS[cmdName] || [];
+    completions.push(...staticArgs.filter(s => s.startsWith(currentArg)));
+
+    // Add flags (when typing something that starts with -)
+    if (currentArg.startsWith('-') || currentArg === '') {
+      const flags = COMMAND_FLAGS[cmdName] || [];
+      completions.push(...flags.filter(f => f.startsWith(currentArg)));
+
+      // Add universal -h and --help flags
+      if ('-h'.startsWith(currentArg) && !completions.includes('-h')) {
+        completions.push('-h');
+      }
+      if ('--help'.startsWith(currentArg) && !completions.includes('--help')) {
+        completions.push('--help');
+      }
+    }
+
+    // Dynamic completions: git branches
+    if (GIT_BRANCH_COMMANDS.includes(cmdName)) {
+      const branches = getGitBranches();
+      completions.push(...branches.filter(b => b.startsWith(currentArg)));
+    }
+
+    // Dynamic completions: session names
+    if (SESSION_COMMANDS.includes(cmdName)) {
+      const sessions = getSessionNames();
+      completions.push(...sessions.filter(s => s.startsWith(currentArg)));
+    }
+
+    // Remove duplicates and sort
+    const uniqueCompletions = [...new Set(completions)].sort();
+
+    // Build full completions with command prefix
+    let prefix = `/${cmdName}`;
+    if (completedArgs.length > 0) {
+      prefix += ' ' + completedArgs.join(' ');
+    }
+    prefix += ' ';
+    const fullCompletions = uniqueCompletions.map(c => prefix + c);
+
+    return [fullCompletions, line];
+  };
+}
+
+/**
+ * Get all available command names (including aliases).
+ * Useful for external tools that need command list.
+ */
+export function getCommandNames(): string[] {
+  const allCommands = getAllCommands();
+  const names: string[] = [];
+
+  for (const cmd of allCommands) {
+    names.push(cmd.name);
+    if (cmd.aliases) {
+      names.push(...cmd.aliases);
+    }
+  }
+
+  return names.sort();
+}
+
+/**
+ * Get subcommands for a specific command.
+ */
+export function getSubcommands(cmdName: string): string[] {
+  return COMMAND_SUBCOMMANDS[cmdName.toLowerCase()] || [];
+}
+
+/**
+ * Get static args for a specific command.
+ */
+export function getStaticArgs(cmdName: string): string[] {
+  return COMMAND_STATIC_ARGS[cmdName.toLowerCase()] || [];
+}
+
+/**
+ * Get flags for a specific command.
+ */
+export function getFlags(cmdName: string): string[] {
+  return COMMAND_FLAGS[cmdName.toLowerCase()] || [];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,6 +280,7 @@ import {
   type RAGConfig,
 } from './rag/index.js';
 import { registerRAGSearchTool, registerSymbolIndexTools } from './tools/index.js';
+import { createCompleter } from './completions.js';
 import { SymbolIndexService } from './symbol-index/index.js';
 import { formatCost, formatTokens } from './usage.js';
 import { loadPluginsFromDirectory, getPluginsDir } from './plugins.js';
@@ -2230,8 +2231,9 @@ async function main() {
   }
   console.log();
 
-  // Create readline interface with history (needed for confirmation prompts)
+  // Create readline interface with history and tab completion
   const history = loadHistory();
+  const completer = createCompleter();
   const rl = createInterface({
     input: process.stdin,
     output: process.stdout,
@@ -2239,6 +2241,7 @@ async function main() {
     historySize: MAX_HISTORY_SIZE,
     terminal: true,
     prompt: chalk.bold.cyan('\nYou: '),
+    completer,
   });
 
   // Track if readline is closed (for piped input)

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import {
+  createCompleter,
+  getCommandNames,
+  getSubcommands,
+  getStaticArgs,
+  getFlags,
+} from '../src/completions';
+
+// Register commands before tests
+import { registerGitCommands } from '../src/commands/git-commands';
+import { registerCodeCommands } from '../src/commands/code-commands';
+import { registerWorkflowCommands } from '../src/commands/workflow-commands';
+import { registerSessionCommands } from '../src/commands/session-commands';
+import { registerConfigCommands } from '../src/commands/config-commands';
+import { registerModelCommands } from '../src/commands/model-commands';
+import { registerMemoryCommands } from '../src/commands/memory-commands';
+import { registerHistoryCommands } from '../src/commands/history-commands';
+import { registerUsageCommands } from '../src/commands/usage-commands';
+import { registerPluginCommands } from '../src/commands/plugin-commands';
+import { registerImportCommands } from '../src/commands/import-commands';
+import { registerCompressionCommands } from '../src/commands/compression-commands';
+import { registerApprovalCommands } from '../src/commands/approval-commands';
+import { registerSymbolCommands } from '../src/commands/symbol-commands';
+import { registerRAGCommands } from '../src/commands/rag-commands';
+
+describe('Command Completions', () => {
+  beforeAll(() => {
+    // Register all commands
+    registerGitCommands();
+    registerCodeCommands();
+    registerWorkflowCommands();
+    registerSessionCommands();
+    registerConfigCommands();
+    registerModelCommands();
+    registerMemoryCommands();
+    registerHistoryCommands();
+    registerUsageCommands();
+    registerPluginCommands();
+    registerImportCommands();
+    registerCompressionCommands();
+    registerApprovalCommands();
+    registerSymbolCommands();
+    registerRAGCommands();
+  });
+
+  describe('createCompleter', () => {
+    describe('command name completion', () => {
+      it('completes command names starting with partial input', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/br');
+        expect(completions).toContain('/branch ');
+      });
+
+      it('completes multiple matching commands', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/co');
+        expect(completions.some(c => c.startsWith('/co'))).toBe(true);
+      });
+
+      it('returns empty for non-matching prefix', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/xyz');
+        expect(completions).toHaveLength(0);
+      });
+
+      it('completes aliases', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/ci');
+        expect(completions).toContain('/ci ');
+      });
+
+      it('returns all commands for just /', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/');
+        expect(completions.length).toBeGreaterThan(10);
+      });
+    });
+
+    describe('subcommand completion', () => {
+      it('completes subcommands for /branch', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/branch ');
+        expect(completions).toContain('/branch list');
+        expect(completions).toContain('/branch create');
+        expect(completions).toContain('/branch switch');
+        expect(completions).toContain('/branch delete');
+        expect(completions).toContain('/branch rename');
+      });
+
+      it('completes partial subcommands', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/branch cr');
+        expect(completions).toContain('/branch create');
+        expect(completions).not.toContain('/branch list');
+      });
+
+      it('completes subcommands for /stash', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/stash ');
+        expect(completions).toContain('/stash save');
+        expect(completions).toContain('/stash list');
+        expect(completions).toContain('/stash pop');
+      });
+
+      it('completes subcommands for /config', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/config ');
+        expect(completions).toContain('/config init');
+        expect(completions).toContain('/config show');
+        expect(completions).toContain('/config example');
+      });
+
+      it('completes subcommands for /usage', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/usage ');
+        expect(completions).toContain('/usage session');
+        expect(completions).toContain('/usage today');
+        expect(completions).toContain('/usage week');
+        expect(completions).toContain('/usage month');
+      });
+    });
+
+    describe('static argument completion', () => {
+      it('completes provider names for /models', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/models ');
+        expect(completions).toContain('/models anthropic');
+        expect(completions).toContain('/models openai');
+        expect(completions).toContain('/models ollama');
+      });
+
+      it('completes partial provider names', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/models an');
+        expect(completions).toContain('/models anthropic');
+        expect(completions).not.toContain('/models openai');
+      });
+
+      it('completes commit types for /commit', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/commit ');
+        expect(completions).toContain('/commit feat');
+        expect(completions).toContain('/commit fix');
+        expect(completions).toContain('/commit docs');
+      });
+
+      it('completes partial commit types', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/commit fe');
+        expect(completions).toContain('/commit feat');
+        expect(completions).not.toContain('/commit fix');
+      });
+    });
+
+    describe('flag completion', () => {
+      it('completes flags for /models', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/models --');
+        expect(completions).toContain('/models --local');
+      });
+
+      it('completes flags for /symbols', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/symbols --');
+        expect(completions).toContain('/symbols --deep');
+        expect(completions).toContain('/symbols --jobs');
+      });
+
+      it('adds -h and --help for all commands', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/config -');
+        expect(completions).toContain('/config -h');
+        expect(completions).toContain('/config --help');
+      });
+
+      it('completes partial flag', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/models --l');
+        expect(completions).toContain('/models --local');
+      });
+    });
+
+    describe('non-command input', () => {
+      it('returns empty for non-command input', () => {
+        const completer = createCompleter();
+        const [completions] = completer('hello world');
+        expect(completions).toHaveLength(0);
+      });
+
+      it('returns empty for empty input', () => {
+        const completer = createCompleter();
+        const [completions] = completer('');
+        expect(completions).toHaveLength(0);
+      });
+
+      it('does not complete double-slash comments', () => {
+        const completer = createCompleter();
+        const [completions] = completer('// this is a comment');
+        expect(completions).toHaveLength(0);
+      });
+    });
+
+    describe('edge cases', () => {
+      it('handles trailing spaces correctly', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/branch ');
+        expect(completions.length).toBeGreaterThan(0);
+        // All completions should start with /branch
+        for (const c of completions) {
+          expect(c.startsWith('/branch ')).toBe(true);
+        }
+      });
+
+      it('handles multiple arguments', () => {
+        const completer = createCompleter();
+        // After first arg, still show flags
+        const [completions] = completer('/models anthropic -');
+        expect(completions).toContain('/models anthropic -h');
+      });
+
+      it('preserves case in completions', () => {
+        const completer = createCompleter();
+        const [completions] = completer('/Branch');
+        // Command names are lowercase
+        expect(completions.some(c => c.toLowerCase().includes('branch'))).toBe(true);
+      });
+    });
+  });
+
+  describe('getCommandNames', () => {
+    it('returns all command names and aliases', () => {
+      const names = getCommandNames();
+      expect(names).toContain('branch');
+      expect(names).toContain('br'); // alias
+      expect(names).toContain('commit');
+      expect(names).toContain('ci'); // alias
+      expect(names).toContain('config');
+      expect(names).toContain('cfg'); // alias
+    });
+
+    it('returns sorted names', () => {
+      const names = getCommandNames();
+      const sorted = [...names].sort();
+      expect(names).toEqual(sorted);
+    });
+  });
+
+  describe('getSubcommands', () => {
+    it('returns subcommands for branch', () => {
+      const subcommands = getSubcommands('branch');
+      expect(subcommands).toContain('list');
+      expect(subcommands).toContain('create');
+    });
+
+    it('returns empty for command without subcommands', () => {
+      const subcommands = getSubcommands('help');
+      expect(subcommands).toHaveLength(0);
+    });
+
+    it('is case-insensitive', () => {
+      const subcommands = getSubcommands('BRANCH');
+      expect(subcommands).toContain('list');
+    });
+  });
+
+  describe('getStaticArgs', () => {
+    it('returns static args for models', () => {
+      const args = getStaticArgs('models');
+      expect(args).toContain('anthropic');
+      expect(args).toContain('openai');
+      expect(args).toContain('ollama');
+    });
+
+    it('returns commit types for commit', () => {
+      const args = getStaticArgs('commit');
+      expect(args).toContain('feat');
+      expect(args).toContain('fix');
+    });
+
+    it('returns empty for command without static args', () => {
+      const args = getStaticArgs('help');
+      expect(args).toHaveLength(0);
+    });
+  });
+
+  describe('getFlags', () => {
+    it('returns flags for models', () => {
+      const flags = getFlags('models');
+      expect(flags).toContain('--local');
+    });
+
+    it('returns flags for symbols', () => {
+      const flags = getFlags('symbols');
+      expect(flags).toContain('--deep');
+      expect(flags).toContain('--jobs');
+    });
+
+    it('returns empty for command without specific flags', () => {
+      const flags = getFlags('help');
+      expect(flags).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add tab-completion support for slash commands in the REPL
- Complete command names, subcommands, static arguments, flags, and dynamic values (git branches, session names)
- Enables faster command entry and discovery of available options

## Features
- **Command name completion**: `/br<TAB>` → `/branch`
- **Subcommand completion**: `/branch cr<TAB>` → `/branch create`
- **Static argument completion**: `/models an<TAB>` → `/models anthropic`
- **Flag completion**: `/models --<TAB>` → `/models --local`
- **Dynamic completion**: Git branches for `/branch`, `/merge`, `/rebase`; Session names for `/load`, `/sessions`

## Implementation
| File | Changes |
|------|---------|
| `src/completions.ts` | New module with `createCompleter()` function |
| `src/index.ts` | Added completer to readline interface |
| `tests/completions.test.ts` | 35 comprehensive tests |

## Test plan
- [x] All 35 completion tests pass
- [x] Existing tests unaffected (712 pass, symbol-index skipped due to native module)
- [ ] Manual testing: run `codi` and test TAB completion for various commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)