### PR TITLE
fix: trim repeated tool results

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -373,6 +373,7 @@ function generateSystemPrompt(projectInfo: ProjectInfo | null, useTools: boolean
 - When you need a tool, emit a tool call (do not describe tool usage in plain text).
 - Do not put tool-call syntax or commands in your normal response.
 - Do not present shell commands in fenced code blocks like \`\`\`bash\`\`\`; use the bash tool instead.
+- Only call tools when you need file contents, codebase search results, or command output to answer the user's request. If the user asks for general guidance or meta/instructional help, respond directly without calling tools.
 - Wait for tool results before continuing; if a tool fails, explain and try a different tool.
 
 ## Available Tools


### PR DESCRIPTION
## Summary
- Truncate old text-based tool results for extracted tool calls so large outputs aren’t resent verbatim
- Extend tool-result truncation tests to cover plain-text tool results
- Clarify system prompt to avoid tool calls for meta/guidance questions

## Testing
- pnpm build
- pnpm test