### PR TITLE
feat: parallel execution for independent tool calls

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -55,11 +55,7 @@ import {
   type ApprovedPattern,
   type ApprovedPathPattern,
 } from './approvals.js';
-import {
-  batchToolCalls,
-  getBatchStats,
-  type ToolBatch,
-} from './tool-executor.js';
+import { batchToolCalls, getBatchStats } from './tool-executor.js';
 
 /**
  * Information about a tool call for confirmation.


### PR DESCRIPTION
## Summary

- Adds parallel execution for independent tool calls to improve performance
- Read-only tools (read_file, glob, grep, etc.) on different files now execute concurrently
- Mutating tools (write_file, edit_file, bash) continue to execute sequentially for safety

## Changes

- **New file: `src/tool-executor.ts`**
  - Tool categories: `READ_ONLY_TOOLS` and `MUTATING_TOOLS`
  - `batchToolCalls()`: Groups tool calls by dependency
  - `getBatchStats()`: Returns batching statistics for logging

- **Updated: `src/agent.ts`**
  - Refactored tool execution into two phases:
    1. Phase 1 - Confirmation (sequential): Handle confirmations/diffs
    2. Phase 2 - Execution (parallel where safe): Batch and execute

## Batching Strategy

| Scenario | Behavior |
|----------|----------|
| Multiple consecutive read-only tools on different files | **Parallel** |
| Mutating tools | **Sequential** |
| Read after write on same file | **Wait** for write |
| Read after write on different file | **Parallel** |
| Bash commands | **Sequential** (can't detect dependencies) |

## Example

```
read_file(a.ts)   ─┐
read_file(b.ts)   ─┼─► Parallel batch 1
read_file(c.ts)   ─┘
write_file(a.ts)  ─── Sequential batch 2
read_file(a.ts)   ─── Sequential batch 3 (depends on write)
```

## Test plan

- [x] Added 20 unit tests for batching behavior
- [x] All existing tests pass (1394 tests)
- [ ] Manual testing with multi-tool model responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)