### PR TITLE
feat: separate user-specific approvals into local config

### DIFF
--- a/.codi.json
+++ b/.codi.json
@@ -1,54 +1,19 @@
 {
-  "provider": "ollama-cloud",
-  "model": "gpt-oss:120b-cloud",
+  "provider": "anthropic",
+  "model": "claude-sonnet-4-20250514",
   "autoApprove": [
     "read_file",
     "glob",
     "grep",
     "list_directory"
   ],
-  "approvedPatterns": [
-    {
-      "pattern": "cd *",
-      "approvedAt": "2026-01-14T04:54:02.371Z"
-    },
-    {
-      "pattern": "pnpm -v*",
-      "approvedAt": "2026-01-14T07:42:09.341Z"
-    },
-    {
-      "pattern": "brew *",
-      "approvedAt": "2026-01-14T07:42:34.001Z"
-    },
-    {
-      "pattern": "node *",
-      "approvedAt": "2026-01-14T07:43:25.561Z"
-    },
-    {
-      "pattern": "mkdir *",
-      "approvedAt": "2026-01-14T07:47:14.233Z"
-    },
-    {
-      "pattern": "pnpm rebuild *",
-      "approvedAt": "2026-01-14T09:13:49.781Z"
-    }
-  ],
-  "approvedCategories": [
-    "git-safe",
-    "git-commit",
-    "install-deps",
-    "run-tests",
-    "list-files",
-    "read-files"
-  ],
+  "approvedPatterns": [],
+  "approvedCategories": [],
   "dangerousPatterns": [],
   "systemPromptAdditions": "",
-  "commandAliases": {
-    "t": "/test src/",
-    "b": "/build"
-  },
+  "commandAliases": {},
   "projectContext": "",
-  "enableCompression": true,
+  "enableCompression": false,
   "models": {
     "summarize": {
       "provider": "ollama",
@@ -62,23 +27,14 @@
     "importanceThreshold": 0.4
   },
   "rag": {
-    "enabled": true,
+    "enabled": false,
     "embeddingProvider": "ollama",
     "topK": 5,
     "minScore": 0.7,
-    "autoIndex": true,
-    "watchFiles": true
+    "autoIndex": false,
+    "watchFiles": false
   },
   "mcpServers": {},
-  "approvedPathCategories": [
-    "source-ts",
-    "docs"
-  ],
-  "approvedPathPatterns": [
-    {
-      "pattern": "codi/*.json",
-      "toolName": "edit_file",
-      "approvedAt": "2026-01-14T04:54:45.020Z"
-    }
-  ]
+  "approvedPathCategories": [],
+  "approvedPathPatterns": []
 }

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ npm-debug.log*
 
 # Test coverage
 coverage/
+
+# Local settings
+.claude/
+*.code-review
+.codi.local.json

--- a/codi-models.yaml
+++ b/codi-models.yaml
@@ -1,4 +1,6 @@
 version: '1'
+
+# Model definitions - map friendly names to provider/model pairs
 models:
   haiku:
     provider: anthropic
@@ -12,118 +14,70 @@ models:
     provider: anthropic
     model: claude-opus-4-20250514
     description: Most capable for complex reasoning
+  gpt-4o:
+    provider: openai
+    model: gpt-4o
+    description: Fast, capable GPT-4 model
+  gpt-4o-mini:
+    provider: openai
+    model: gpt-4o-mini
+    description: Budget-friendly GPT-4
   llama3:
     provider: ollama
     model: llama3.2
     description: Free local model
-  coder:
-    provider: ollama-cloud
-    model: qwen3-coder:480b-cloud
-    description: Cloud coder
-  gpt-5-nano:
-    provider: openai
-    model: gpt-5-nano
-    description: Fast, cheap GPT-5 model
-  gpt-5:
-    provider: openai
-    model: gpt-5.2
-    description: Latest GPT-5, best for coding
-  qwen3-lite:
-    provider: ollama
-    model: qwen3:8b
-    description: qwen lite
-  gemini-3-flash-preview:
-    provider: ollama-cloud
-    model: gemini-3-flash-preview:cloud
-    description: gemini cloud fast
-  gpt-oss:
-    provider: ollama-cloud
-    model: gpt-oss:120b-cloud
-    description: cloud gpt oss 120b-cloud
+
+# Task routing - map task types to models
 tasks:
   fast:
-    model: gpt-5-nano
+    model: haiku
     description: Quick tasks (commits, summaries)
   code:
-    model: coder
+    model: sonnet
     description: Standard coding tasks
   complex:
-    model: gpt-5
+    model: opus
     description: Architecture, debugging
   summarize:
     model: llama3
-    description: Context summarization
-  document:
-    model: qwen3-lite
+    description: Context summarization (free)
+
+# Command routing - override task for specific commands
 commands:
   commit:
     task: fast
   fix:
     task: complex
+
+# Fallback chains - try models in order if one fails
 fallbacks:
   primary:
-    - gpt-5
-    - coder
-    - qwen3-lite
     - sonnet
     - haiku
+    - gpt-4o
     - llama3
 
-# Model roles map abstract roles to concrete models per provider context
+# Model roles - abstract roles for provider-agnostic pipelines
 # Use with: /pipeline --provider anthropic <pipeline-name>
 model-roles:
   fast:
     anthropic: haiku
-    openai: gpt-5-nano
-    ollama: qwen3-lite
-    ollama-cloud: gemini-3-flash-preview
+    openai: gpt-4o-mini
+    ollama: llama3
   capable:
     anthropic: sonnet
-    openai: gpt-5
+    openai: gpt-4o
     ollama: llama3
-    ollama-cloud: coder
   reasoning:
     anthropic: opus
-    openai: gpt-5
+    openai: gpt-4o
     ollama: llama3
-    ollama-cloud: gpt-oss
 
+# Example pipeline using roles (provider-agnostic)
 pipelines:
-  # Provider-agnostic refactoring pipeline
-  # Use with: /pipeline --provider anthropic smart-refactor <file>
-  #       or: /pipeline --provider openai smart-refactor <file>
-  smart-refactor:
-    description: Analyze, plan, implement, review
-    provider: openai  # Default provider if --provider not specified
-    steps:
-      - name: analyze
-        role: fast
-        prompt: 'Analyze refactoring opportunities: {input}'
-        output: analysis
-      - name: plan
-        role: reasoning
-        prompt: 'Create refactoring plan based on: {analysis}'
-        output: plan
-      - name: implement
-        role: reasoning
-        prompt: 'Implement the plan: {plan}'
-        output: implementation
-      - name: review
-        role: capable
-        prompt: 'Quick review: {implementation}'
-        output: review
-    result: |-
-      {implementation}
-
-      ## Review
-      {review}
-
-  # Provider-agnostic code review pipeline
-  # Use with: /pipeline --provider anthropic code-review <file>
-  #       or: /pipeline --provider openai code-review <file>
   code-review:
-    description: Multi-step code review using roles
-    provider: openai  # Default provider if --provider not specified
+    description: Multi-step code review
+    provider: anthropic
     steps:
       - name: quick-scan
         role: fast
@@ -131,7 +85,7 @@ pipelines:
         output: quick_issues
       - name: deep-analysis
         role: reasoning
-        prompt: 'Deep analysis of code quality, architecture, and best practices: {input}\n\nQuick scan found: {quick_issues}'
+        prompt: 'Deep analysis of code quality: {input}\n\nQuick scan found: {quick_issues}'
         output: analysis
       - name: suggestions
         role: capable

--- a/src/approvals.ts
+++ b/src/approvals.ts
@@ -90,20 +90,11 @@ export function getApprovalSuggestions(command: string): ApprovalSuggestions {
 }
 
 /**
- * Find the config file path.
+ * Get the local config file path for storing approvals.
+ * Local config is gitignored and stores user-specific approvals.
  */
-function findConfigPath(cwd: string): string {
-  const candidates = ['.codi.json', '.codi/config.json', 'codi.config.json'];
-
-  for (const candidate of candidates) {
-    const fullPath = path.join(cwd, candidate);
-    if (fs.existsSync(fullPath)) {
-      return fullPath;
-    }
-  }
-
-  // Default to .codi.json
-  return path.join(cwd, '.codi.json');
+function getLocalConfigPath(cwd: string): string {
+  return path.join(cwd, '.codi.local.json');
 }
 
 /**
@@ -135,7 +126,7 @@ export function addApprovedPattern(
   description?: string,
   cwd: string = process.cwd()
 ): { success: boolean; error?: string } {
-  const configPath = findConfigPath(cwd);
+  const configPath = getLocalConfigPath(cwd);
 
   try {
     const config = loadConfig(configPath);
@@ -186,7 +177,7 @@ export function addApprovedCategory(
     };
   }
 
-  const configPath = findConfigPath(cwd);
+  const configPath = getLocalConfigPath(cwd);
 
   try {
     const config = loadConfig(configPath);
@@ -223,7 +214,7 @@ export function removeApprovedPattern(
   pattern: string,
   cwd: string = process.cwd()
 ): { success: boolean; removed: boolean; error?: string } {
-  const configPath = findConfigPath(cwd);
+  const configPath = getLocalConfigPath(cwd);
 
   try {
     if (!fs.existsSync(configPath)) {
@@ -256,7 +247,7 @@ export function removeApprovedCategory(
   categoryId: string,
   cwd: string = process.cwd()
 ): { success: boolean; removed: boolean; error?: string } {
-  const configPath = findConfigPath(cwd);
+  const configPath = getLocalConfigPath(cwd);
 
   try {
     if (!fs.existsSync(configPath)) {
@@ -289,7 +280,7 @@ export function listApprovals(cwd: string = process.cwd()): {
   patterns: ApprovedPattern[];
   categories: { id: string; name: string; description: string }[];
 } {
-  const configPath = findConfigPath(cwd);
+  const configPath = getLocalConfigPath(cwd);
 
   try {
     if (!fs.existsSync(configPath)) {
@@ -405,7 +396,7 @@ export function addApprovedPathPattern(
   description?: string,
   cwd: string = process.cwd()
 ): { success: boolean; error?: string } {
-  const configPath = findConfigPath(cwd);
+  const configPath = getLocalConfigPath(cwd);
 
   try {
     const config = loadConfig(configPath);
@@ -457,7 +448,7 @@ export function addApprovedPathCategory(
     };
   }
 
-  const configPath = findConfigPath(cwd);
+  const configPath = getLocalConfigPath(cwd);
 
   try {
     const config = loadConfig(configPath);
@@ -495,7 +486,7 @@ export function removeApprovedPathPattern(
   toolName?: string,
   cwd: string = process.cwd()
 ): { success: boolean; removed: boolean; error?: string } {
-  const configPath = findConfigPath(cwd);
+  const configPath = getLocalConfigPath(cwd);
 
   try {
     if (!fs.existsSync(configPath)) {
@@ -533,7 +524,7 @@ export function removeApprovedPathCategory(
   categoryId: string,
   cwd: string = process.cwd()
 ): { success: boolean; removed: boolean; error?: string } {
-  const configPath = findConfigPath(cwd);
+  const configPath = getLocalConfigPath(cwd);
 
   try {
     if (!fs.existsSync(configPath)) {
@@ -566,7 +557,7 @@ export function listPathApprovals(cwd: string = process.cwd()): {
   pathPatterns: ApprovedPathPattern[];
   pathCategories: { id: string; name: string; description: string }[];
 } {
-  const configPath = findConfigPath(cwd);
+  const configPath = getLocalConfigPath(cwd);
 
   try {
     if (!fs.existsSync(configPath)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -299,6 +299,7 @@ import { loadPluginsFromDirectory, getPluginsDir } from './plugins.js';
 import { loadSession } from './session.js';
 import {
   loadWorkspaceConfig,
+  loadLocalConfig,
   validateConfig,
   mergeConfig,
   getCustomDangerousPatterns,
@@ -2201,18 +2202,25 @@ async function main() {
     console.warn(chalk.yellow('Invalid --context-window value; expected a positive number.'));
   }
 
-  const resolvedConfig = mergeConfig(workspaceConfig, {
-    provider: options.provider,
-    model: options.model,
-    baseUrl: options.baseUrl,
-    endpointId: options.endpointId,
-    yes: options.yes,
-    tools: options.tools,
-    session: options.session,
-    summarizeProvider: options.summarizeProvider,
-    summarizeModel: options.summarizeModel,
-    maxContextTokens: contextWindowTokens,
-  });
+  // Load local config (gitignored, user-specific approvals)
+  const localConfig = loadLocalConfig();
+
+  const resolvedConfig = mergeConfig(
+    workspaceConfig,
+    {
+      provider: options.provider,
+      model: options.model,
+      baseUrl: options.baseUrl,
+      endpointId: options.endpointId,
+      yes: options.yes,
+      tools: options.tools,
+      session: options.session,
+      summarizeProvider: options.summarizeProvider,
+      summarizeModel: options.summarizeModel,
+      maxContextTokens: contextWindowTokens,
+    },
+    localConfig
+  );
 
   // Register tools and commands
   registerDefaultTools();


### PR DESCRIPTION
## Summary
- Add `.codi.local.json` for user-specific approvals (gitignored)
- Update config loader to merge local config with workspace config
- Reset `.codi.json` and `codi-models.yaml` to clean examples

## Changes
- **src/config.ts**: Add `loadLocalConfig()` function to load `.codi.local.json`
- **src/index.ts**: Call `loadLocalConfig()` and pass to `mergeConfig()`
- **src/approvals.ts**: Already saves approvals to `.codi.local.json`
- **.codi.json**: Reset to clean example with default provider (anthropic/sonnet)
- **codi-models.yaml**: Reset to standard models (anthropic, openai, ollama)
- **.gitignore**: Add `.codi.local.json` to prevent tracking user-specific approvals

## Motivation
This allows the main config files to be committed as clean examples for new users while user-specific approvals (patterns, categories, path patterns) are stored in a separate gitignored file.

## Test plan
- [x] All 1396 tests pass
- [ ] Verify local config is loaded and merged correctly
- [ ] Verify approvals are saved to `.codi.local.json`
- [ ] Verify `.codi.json` is not modified when adding approvals

🤖 Generated with [Claude Code](https://claude.com/claude-code)