### PR TITLE
feat: add interactive command picker when typing /

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.0",
+    "@inquirer/prompts": "^8.2.0",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "chalk": "^5.3.0",
     "chokidar": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.32.0
         version: 0.32.1
+      '@inquirer/prompts':
+        specifier: ^8.2.0
+        version: 8.2.0(@types/node@22.19.6)
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
         version: 1.25.2(hono@4.11.4)(zod@3.25.76)
@@ -417,6 +420,140 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@inquirer/ansi@2.0.3':
+    resolution: {integrity: sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/checkbox@5.0.4':
+    resolution: {integrity: sha512-DrAMU3YBGMUAp6ArwTIp/25CNDtDbxk7UjIrrtM25JVVrlVYlVzHh5HR1BDFu9JMyUoZ4ZanzeaHqNDttf3gVg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.0.4':
+    resolution: {integrity: sha512-WdaPe7foUnoGYvXzH4jp4wH/3l+dBhZ3uwhKjXjwdrq5tEIFaANxj6zrGHxLdsIA0yKM0kFPVcEalOZXBB5ISA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.1':
+    resolution: {integrity: sha512-hV9o15UxX46OyQAtaoMqAOxGR8RVl1aZtDx1jHbCtSJy1tBdTfKxLPKf7utsE4cRy4tcmCQ4+vdV+ca+oNxqNA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.0.4':
+    resolution: {integrity: sha512-QI3Jfqcv6UO2/VJaEFONH8Im1ll++Xn/AJTBn9Xf+qx2M+H8KZAdQ5sAe2vtYlo+mLW+d7JaMJB4qWtK4BG3pw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.0.4':
+    resolution: {integrity: sha512-0I/16YwPPP0Co7a5MsomlZLpch48NzYfToyqYAOWtBmaXSB80RiNQ1J+0xx2eG+Wfxt0nHtpEWSRr6CzNVnOGg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@2.0.3':
+    resolution: {integrity: sha512-LgyI7Agbda74/cL5MvA88iDpvdXI2KuMBCGRkbCl2Dg1vzHeOgs+s0SDcXV7b+WZJrv2+ERpWSM65Fpi9VfY3w==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.3':
+    resolution: {integrity: sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/input@5.0.4':
+    resolution: {integrity: sha512-4B3s3jvTREDFvXWit92Yc6jF1RJMDy2VpSqKtm4We2oVU65YOh2szY5/G14h4fHlyQdpUmazU5MPCFZPRJ0AOw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.0.4':
+    resolution: {integrity: sha512-CmMp9LF5HwE+G/xWsC333TlCzYYbXMkcADkKzcawh49fg2a1ryLc7JL1NJYYt1lJ+8f4slikNjJM9TEL/AljYQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.0.4':
+    resolution: {integrity: sha512-ZCEPyVYvHK4W4p2Gy6sTp9nqsdHQCfiPXIP9LbJVW4yCinnxL/dDDmPaEZVysGrj8vxVReRnpfS2fOeODe9zjg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.2.0':
+    resolution: {integrity: sha512-rqTzOprAj55a27jctS3vhvDDJzYXsr33WXTjODgVOru21NvBo9yIgLIAf7SBdSV0WERVly3dR6TWyp7ZHkvKFA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.2.0':
+    resolution: {integrity: sha512-CciqGoOUMrFo6HxvOtU5uL8fkjCmzyeB6fG7O1vdVAZVSopUBYECOwevDBlqNLyyYmzpm2Gsn/7nLrpruy9RFg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.1.0':
+    resolution: {integrity: sha512-EAzemfiP4IFvIuWnrHpgZs9lAhWDA0GM3l9F4t4mTQ22IFtzfrk8xbkMLcAN7gmVML9O/i+Hzu8yOUyAaL6BKA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.0.4':
+    resolution: {integrity: sha512-s8KoGpPYMEQ6WXc0dT9blX2NtIulMdLOO3LA1UKOiv7KFWzlJ6eLkEYTDBIi+JkyKXyn8t/CD6TinxGjyLt57g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.3':
+    resolution: {integrity: sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
@@ -758,6 +895,9 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -783,6 +923,10 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1302,6 +1446,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1826,6 +1974,10 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -2033,6 +2185,125 @@ snapshots:
   '@hono/node-server@1.19.9(hono@4.11.4)':
     dependencies:
       hono: 4.11.4
+
+  '@inquirer/ansi@2.0.3': {}
+
+  '@inquirer/checkbox@5.0.4(@types/node@22.19.6)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/core': 11.1.1(@types/node@22.19.6)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.6)
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/confirm@6.0.4(@types/node@22.19.6)':
+    dependencies:
+      '@inquirer/core': 11.1.1(@types/node@22.19.6)
+      '@inquirer/type': 4.0.3(@types/node@22.19.6)
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/core@11.1.1(@types/node@22.19.6)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.6)
+      cli-width: 4.1.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 9.0.2
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/editor@5.0.4(@types/node@22.19.6)':
+    dependencies:
+      '@inquirer/core': 11.1.1(@types/node@22.19.6)
+      '@inquirer/external-editor': 2.0.3(@types/node@22.19.6)
+      '@inquirer/type': 4.0.3(@types/node@22.19.6)
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/expand@5.0.4(@types/node@22.19.6)':
+    dependencies:
+      '@inquirer/core': 11.1.1(@types/node@22.19.6)
+      '@inquirer/type': 4.0.3(@types/node@22.19.6)
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/external-editor@2.0.3(@types/node@22.19.6)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/figures@2.0.3': {}
+
+  '@inquirer/input@5.0.4(@types/node@22.19.6)':
+    dependencies:
+      '@inquirer/core': 11.1.1(@types/node@22.19.6)
+      '@inquirer/type': 4.0.3(@types/node@22.19.6)
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/number@4.0.4(@types/node@22.19.6)':
+    dependencies:
+      '@inquirer/core': 11.1.1(@types/node@22.19.6)
+      '@inquirer/type': 4.0.3(@types/node@22.19.6)
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/password@5.0.4(@types/node@22.19.6)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/core': 11.1.1(@types/node@22.19.6)
+      '@inquirer/type': 4.0.3(@types/node@22.19.6)
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/prompts@8.2.0(@types/node@22.19.6)':
+    dependencies:
+      '@inquirer/checkbox': 5.0.4(@types/node@22.19.6)
+      '@inquirer/confirm': 6.0.4(@types/node@22.19.6)
+      '@inquirer/editor': 5.0.4(@types/node@22.19.6)
+      '@inquirer/expand': 5.0.4(@types/node@22.19.6)
+      '@inquirer/input': 5.0.4(@types/node@22.19.6)
+      '@inquirer/number': 4.0.4(@types/node@22.19.6)
+      '@inquirer/password': 5.0.4(@types/node@22.19.6)
+      '@inquirer/rawlist': 5.2.0(@types/node@22.19.6)
+      '@inquirer/search': 4.1.0(@types/node@22.19.6)
+      '@inquirer/select': 5.0.4(@types/node@22.19.6)
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/rawlist@5.2.0(@types/node@22.19.6)':
+    dependencies:
+      '@inquirer/core': 11.1.1(@types/node@22.19.6)
+      '@inquirer/type': 4.0.3(@types/node@22.19.6)
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/search@4.1.0(@types/node@22.19.6)':
+    dependencies:
+      '@inquirer/core': 11.1.1(@types/node@22.19.6)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.6)
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/select@5.0.4(@types/node@22.19.6)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/core': 11.1.1(@types/node@22.19.6)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.6)
+    optionalDependencies:
+      '@types/node': 22.19.6
+
+  '@inquirer/type@4.0.3(@types/node@22.19.6)':
+    optionalDependencies:
+      '@types/node': 22.19.6
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -2372,6 +2643,8 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  chardet@2.1.1: {}
+
   check-error@2.1.3: {}
 
   cheerio-select@2.1.0:
@@ -2408,6 +2681,8 @@ snapshots:
       restore-cursor: 5.1.0
 
   cli-spinners@2.9.2: {}
+
+  cli-width@4.1.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -2931,6 +3206,8 @@ snapshots:
   mkdirp-classic@0.5.3: {}
 
   ms@2.1.3: {}
+
+  mute-stream@3.0.0: {}
 
   nanoid@3.3.11: {}
 
@@ -3515,6 +3792,12 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
+      strip-ansi: 7.1.2
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}

--- a/src/command-picker.ts
+++ b/src/command-picker.ts
@@ -1,0 +1,86 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Interactive Command Picker
+ *
+ * Provides a searchable, navigable list of available commands
+ * when the user types just "/" in the REPL.
+ */
+
+import { search } from '@inquirer/prompts';
+import { getAllCommands, type Command } from './commands/index.js';
+
+interface CommandChoice {
+  name: string;
+  value: string;
+  description: string;
+}
+
+/**
+ * Built-in commands that aren't in the registry but should be shown.
+ */
+const BUILTIN_COMMANDS: CommandChoice[] = [
+  { name: '/help', value: '/help', description: 'Show help message and available commands' },
+  { name: '/clear', value: '/clear', description: 'Clear conversation history and start fresh' },
+  { name: '/compact', value: '/compact', description: 'Summarize old messages to save context tokens' },
+  { name: '/status', value: '/status', description: 'Show current context usage and token count' },
+  { name: '/context', value: '/context', description: 'Show detected project context' },
+  { name: '/exit', value: '/exit', description: 'Exit the assistant' },
+];
+
+/**
+ * Get all commands as choices for the picker.
+ */
+function getCommandChoices(): CommandChoice[] {
+  const registeredCommands = getAllCommands();
+
+  const commandChoices: CommandChoice[] = registeredCommands.map((cmd: Command) => ({
+    name: `/${cmd.name}`,
+    value: `/${cmd.name} `,
+    description: cmd.description,
+  }));
+
+  // Combine built-in and registered commands
+  const allChoices = [...BUILTIN_COMMANDS, ...commandChoices];
+
+  // Sort alphabetically by name
+  allChoices.sort((a, b) => a.name.localeCompare(b.name));
+
+  return allChoices;
+}
+
+/**
+ * Show an interactive command picker and return the selected command.
+ *
+ * @returns The selected command string, or null if cancelled
+ */
+export async function showCommandPicker(): Promise<string | null> {
+  const choices = getCommandChoices();
+
+  try {
+    const selected = await search({
+      message: 'Select a command',
+      source: async (input) => {
+        const searchTerm = (input || '').toLowerCase();
+
+        return choices
+          .filter(
+            (choice) =>
+              choice.name.toLowerCase().includes(searchTerm) ||
+              choice.description.toLowerCase().includes(searchTerm),
+          )
+          .map((choice) => ({
+            name: `${choice.name.padEnd(20)} ${choice.description}`,
+            value: choice.value,
+            description: choice.description,
+          }));
+      },
+    });
+
+    return selected;
+  } catch {
+    // User cancelled (Ctrl+C) or other error
+    return null;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   disableBracketedPaste,
   DEFAULT_PASTE_DEBOUNCE_MS,
 } from './paste-debounce.js';
+import { showCommandPicker } from './command-picker.js';
 import { program } from 'commander';
 import chalk from 'chalk';
 import { readFileSync, appendFileSync, existsSync, statSync } from 'fs';
@@ -456,7 +457,7 @@ function showHelp(projectInfo: ProjectInfo | null): void {
   console.log(chalk.dim('  /compact           - Summarize old messages to save context'));
   console.log(chalk.dim('  /status            - Show current context usage'));
   console.log(chalk.dim('  /context           - Show detected project context'));
-  console.log(chalk.dim('  /exit, /quit       - Exit the assistant'));
+  console.log(chalk.dim('  /exit              - Exit the assistant'));
 
   console.log(chalk.bold('\nCode Assistance:'));
   console.log(chalk.dim('  /explain <file>    - Explain code in a file'));
@@ -2746,6 +2747,18 @@ async function main() {
     if (trimmed === '/help') {
       showHelp(projectInfo);
       rl.prompt();
+      return;
+    }
+
+    // Show interactive command picker when user types just "/"
+    if (trimmed === '/') {
+      const selected = await showCommandPicker();
+      if (selected) {
+        // Process the selected command
+        await handleInput(selected.trim());
+      } else {
+        rl.prompt();
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Add searchable command picker that appears when user types just `/` and presses Enter
- Remove alias display from `/help` output for cleaner display
- Add `@inquirer/prompts` dependency for the interactive picker UI

## Features
- **Interactive picker**: Type `/` alone to see all available commands
- **Search**: Filter commands by typing - searches both command names and descriptions
- **Arrow navigation**: Use up/down arrows to navigate, Enter to select
- **Descriptions**: Each command shows its description inline

## Test plan
- [x] All 1396 existing tests pass
- [ ] Manual test: Type `/` and press Enter to see the picker
- [ ] Manual test: Search by typing to filter commands
- [ ] Manual test: Use arrow keys to navigate and Enter to select
- [ ] Manual test: Press Ctrl+C to cancel without selecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)