### PR TITLE
docs: add website link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 </p>
 
 <p align="center">
+  <a href="https://laynepenney.github.io/codi/">Website</a> •
   <a href="#features">Features</a> •
   <a href="#installation">Installation</a> •
   <a href="#quick-start">Quick Start</a> •


### PR DESCRIPTION
Add link to GitHub Pages site in README navigation.