### PR TITLE
fix: add subcommands property to Command interface

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,6 +9,7 @@ export interface Command {
   description: string;
   usage: string;
   taskType?: string; // Task type for model map routing
+  subcommands?: string[]; // List of subcommand names for parent commands
   execute: (args: string, context: CommandContext) => Promise<string | null>;
 }
 


### PR DESCRIPTION
Add missing subcommands property to Command interface to support parent commands like /code and /git.