### PR TITLE
fix: add /log alias for /git log command

### DIFF
--- a/src/commands/git-commands.ts
+++ b/src/commands/git-commands.ts
@@ -596,6 +596,17 @@ export const prAlias: Command = {
   },
 };
 
+export const logAlias: Command = {
+  name: 'log',
+  aliases: ['history'],
+  description: 'Alias for /git log',
+  usage: '/log [target]',
+  taskType: 'fast',
+  execute: async (args: string, context: CommandContext): Promise<string> => {
+    return logPrompt(args, context);
+  },
+};
+
 // Register all git commands
 export function registerGitCommands(): void {
   registerCommand(gitCommand);
@@ -603,4 +614,5 @@ export function registerGitCommands(): void {
   registerCommand(commitAlias);
   registerCommand(branchAlias);
   registerCommand(prAlias);
+  registerCommand(logAlias);
 }


### PR DESCRIPTION
## Summary
- Added `/log` and `/history` as standalone aliases for `/git log`
- Matches the pattern of other git command aliases (`/commit`, `/branch`, `/pr`)
- Fixes failing E2E test for `/log` command

## Test plan
- [x] All tests pass (1374 passed)
- [x] `/log command E2E > should show git log` now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)