### PR TITLE
fix: use spinner for RAG indexing progress

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2324,14 +2324,17 @@ async function main() {
         console.error(chalk.red(`RAG indexer error: ${err.message}`));
       });
 
-      // Set up progress callback
+      // Set up progress callback using spinner for clean single-line output
       ragIndexer.onProgress = (current, total, file) => {
         if (current === 1 || current === total || current % 10 === 0) {
-          process.stdout.write(chalk.dim(`\rIndexing: ${current}/${total} - ${file.slice(0, 40)}...`.padEnd(60)));
+          spinner.indexing(current, total, file.slice(0, 40));
         }
       };
       ragIndexer.onComplete = (stats) => {
-        console.log(chalk.dim(`\nRAG index: ${stats.totalChunks} chunks from ${stats.totalFiles} files`));
+        spinner.indexingDone(stats.totalFiles, stats.totalChunks);
+      };
+      ragIndexer.onError = (error) => {
+        spinner.fail(chalk.red(`RAG indexer: ${error}`));
       };
 
       // Register with commands and tool

--- a/tests/rag-embeddings.test.ts
+++ b/tests/rag-embeddings.test.ts
@@ -254,7 +254,8 @@ describe('Embedding Providers', () => {
       expect(provider.getName()).toBe('Ollama');
     });
 
-    it('auto-detects OpenAI when API key is available', () => {
+    it('defaults to Ollama for auto mode (free/local)', () => {
+      // Even with OpenAI key available, auto mode prefers Ollama
       process.env.OPENAI_API_KEY = 'test-key';
 
       const provider = createEmbeddingProvider({
@@ -262,10 +263,10 @@ describe('Embedding Providers', () => {
         embeddingProvider: 'auto',
       });
 
-      expect(provider.getName()).toBe('OpenAI');
+      expect(provider.getName()).toBe('Ollama');
     });
 
-    it('falls back to Ollama when OpenAI unavailable', () => {
+    it('defaults to Ollama without any API key', () => {
       delete process.env.OPENAI_API_KEY;
 
       const provider = createEmbeddingProvider({


### PR DESCRIPTION
## Summary
- Replace noisy multi-line indexing output with clean single-line spinner
- Use existing `spinner.indexing()` and `spinner.indexingDone()` methods
- Remove `console.log`/`console.error` calls from indexer.ts, use `onError` callback instead
- Update tests to reflect Ollama as default embedding provider

## Before
```
Indexing: 1/100 - src/index.ts...
Indexing: 10/100 - src/agent.ts...
Indexing: 20/100 - src/config.ts...
Index was repaired, clearing cache to re-index all files...
Failed to index src/foo.ts: error...
```

## After
```
⠋ Indexing 1/100: src/index.ts
```
(single line that updates in place, then shows success)
```
✔ Indexed 100 files (450 chunks)
```

## Test plan
- [x] All 1419 tests pass
- [ ] Manual test: run codi in a project with RAG enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)