### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codi",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Your AI coding wingman - a hybrid assistant supporting Claude, OpenAI, and local models",
   "author": "Layne Penney",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2765,7 +2765,7 @@ async function main() {
       const topic = trimmed.slice(1).trim();
       if (topic) {
         // Search for commands matching the topic
-        const allCommands = getRegisteredCommands();
+        const allCommands = getAllCommands();
         const matches = allCommands.filter(
           (cmd) =>
             cmd.name.includes(topic.toLowerCase()) ||

--- a/src/version.ts
+++ b/src/version.ts
@@ -10,4 +10,4 @@
  * - MINOR: New features, significant refactoring, non-breaking changes
  * - PATCH: Bug fixes, minor improvements
  */
-export const VERSION = '0.10.0';
+export const VERSION = '0.11.0';


### PR DESCRIPTION
## Summary
- Bump version to 0.11.0
- Fix build error: `getRegisteredCommands` → `getAllCommands`

## Changes since v0.10.0
- feat: add ! and ? CLI shortcuts (#43)
- feat: default RAG embeddings to Ollama (#39)
- fix: use spinner for RAG indexing progress (#41)
- docs: comprehensive README update (#42)
- docs: require tests before merging PRs (#44)

## Test plan
- [x] Build passes
- [x] All tests pass (1419 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)