### PR TITLE
feat: default to Claude Opus 4.5 for Anthropic provider

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -13,6 +13,7 @@ import type { ModelInfo } from './providers/base.js';
  */
 const MODEL_PRICING: Record<string, { input: number; output: number }> = {
   // Anthropic Claude models
+  'claude-opus-4-5-20251101': { input: 15.0, output: 75.0 },
   'claude-opus-4-20250514': { input: 15.0, output: 75.0 },
   'claude-sonnet-4-20250514': { input: 3.0, output: 15.0 },
   'claude-3-5-sonnet-20241022': { input: 3.0, output: 15.0 },
@@ -36,6 +37,16 @@ const MODEL_PRICING: Record<string, { input: number; output: number }> = {
  * Static list of known models with their capabilities.
  */
 export const STATIC_MODELS: ModelInfo[] = [
+  // Anthropic Claude 4.5 models
+  {
+    id: 'claude-opus-4-5-20251101',
+    name: 'Claude Opus 4.5',
+    provider: 'Anthropic',
+    capabilities: { vision: true, toolUse: true },
+    contextWindow: 200000,
+    pricing: MODEL_PRICING['claude-opus-4-5-20251101'],
+  },
+
   // Anthropic Claude 4 models
   {
     id: 'claude-opus-4-20250514',

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -8,7 +8,7 @@ import { createProviderResponse } from './response-parser.js';
 import { mapContentBlocks } from './message-converter.js';
 import { getStaticModels } from '../models.js';
 
-const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+const DEFAULT_MODEL = 'claude-opus-4-5-20251101';
 const MAX_TOKENS = 4096;
 
 export class AnthropicProvider extends BaseProvider {

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -19,6 +19,7 @@ const USAGE_FILE = path.join(USAGE_DIR, 'usage.json');
  */
 const MODEL_PRICING: Record<string, { input: number; output: number }> = {
   // Anthropic Claude models
+  'claude-opus-4-5-20251101': { input: 15.0, output: 75.0 },
   'claude-opus-4-20250514': { input: 15.0, output: 75.0 },
   'claude-sonnet-4-20250514': { input: 3.0, output: 15.0 },
   'claude-3-5-sonnet-20241022': { input: 3.0, output: 15.0 },


### PR DESCRIPTION
## Summary
- Update default Anthropic model from Claude Sonnet 4 to Claude Opus 4.5
- Add Opus 4.5 (claude-opus-4-5-20251101) to static models list
- Add Opus 4.5 pricing to usage tracking

## Test plan
- [x] Build passes
- [x] All tests pass (1419 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)