### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codi",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Your AI coding wingman - a hybrid assistant supporting Claude, OpenAI, and local models",
   "author": "Layne Penney",
   "license": "Apache-2.0",

--- a/src/version.ts
+++ b/src/version.ts
@@ -10,4 +10,4 @@
  * - MINOR: New features, significant refactoring, non-breaking changes
  * - PATCH: Bug fixes, minor improvements
  */
-export const VERSION = '0.11.0';
+export const VERSION = '0.12.0';


### PR DESCRIPTION
## Summary
Bump version to 0.12.0

## Changes since v0.11.0
- feat: default to Claude Opus 4.5 for Anthropic provider (#47)
- fix: handle malformed JSON with trailing quotes after numbers (#46)

## Test plan
- [x] Build passes
- [x] All tests pass (1425 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)