### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Codi are documented in this file.
 
-## [Unreleased]
+## [0.13.0] - 2026-01-18
 
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codi",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Your AI coding wingman - a hybrid assistant supporting Claude, OpenAI, and local models",
   "author": "Layne Penney",
   "license": "Apache-2.0",

--- a/src/version.ts
+++ b/src/version.ts
@@ -10,4 +10,4 @@
  * - MINOR: New features, significant refactoring, non-breaking changes
  * - PATCH: Bug fixes, minor improvements
  */
-export const VERSION = '0.12.0';
+export const VERSION = '0.13.0';


### PR DESCRIPTION
## Summary
Bump version to 0.13.0 for release.

## Changes
- package.json: 0.12.0 → 0.13.0
- src/version.ts: 0.12.0 → 0.13.0
- CHANGELOG.md: [Unreleased] → [0.13.0] - 2026-01-18

## Test plan
- [x] Build passes
- [x] All 1425 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)