### PR TITLE
docs: add banner to GitHub Pages hero section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -251,6 +251,14 @@
       font-weight: 600;
     }
 
+    .hero-banner {
+      max-width: 600px;
+      width: 100%;
+      height: auto;
+      margin-bottom: 1.5rem;
+      border-radius: 12px;
+    }
+
     .hero p {
       font-size: 1.25rem;
       color: var(--text-muted);
@@ -819,9 +827,8 @@
 
   <section class="hero">
     <div class="hero-content">
-      <h1 class="animate-in">Codi</h1>
-      <p class="hero-tagline animate-in delay-1">Your AI Coding Wingman</p>
-      <p class="animate-in delay-2">Multi-provider AI assistant for the terminal. Read, write, search, and refactor code with Claude, OpenAI, Ollama, and more.</p>
+      <img src="assets/banner.png" alt="Codi - Your AI Coding Wingman" class="hero-banner animate-in" />
+      <p class="animate-in delay-1">Multi-provider AI assistant for the terminal. Read, write, search, and refactor code with Claude, OpenAI, Ollama, and more.</p>
 
       <div class="badges animate-in delay-2">
         <span class="badge">


### PR DESCRIPTION
## Summary
- Replace text-based hero title with banner.png on GitHub Pages
- Consistent branding between README and website

🤖 Generated with [Claude Code](https://claude.ai/code)