### PR TITLE
fix: include bash code blocks in hasToolTrace pattern

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -747,7 +747,7 @@ Always use tools to interact with the filesystem rather than asking the user to 
           reasoningText &&
           contentText === reasoningText
         );
-        const toolTracePattern = /\[(?:Calling|Running)\s+[a-z_][a-z0-9_]*\]|\{\s*"name"\s*:\s*"[a-z_][a-z0-9_]*"/i;
+        const toolTracePattern = /\[(?:Calling|Running)\s+[a-z_][a-z0-9_]*\]|\{\s*"name"\s*:\s*"[a-z_][a-z0-9_]*"|```(?:bash|sh|shell|zsh)\s*\n/i;
         const hasToolTrace = (text: string): boolean => toolTracePattern.test(text);
 
         let extractedCalls: ToolCall[] = [];


### PR DESCRIPTION
## Summary
Fixes issue where bash code blocks weren't triggering tool extraction because the `hasToolTrace` pattern didn't match them.

## Problem
The `hasToolTrace` pattern gates whether `extractToolCallsFromText` runs. It only matched:
- `[Calling tool_name]`
- `{"name": "tool_name"`

But models like `qwen3-coder` output bash in code blocks:
```bash
ls src/
```

## Solution
Added ` ```bash` (and sh/shell/zsh variants) to the `hasToolTrace` regex pattern.

## Test
```
=== Native Response ===
Tool calls: 0
Has tool trace (bash block): true

=== Extracted Tool Calls ===
[{ "name": "bash", "input": { "command": "ls src/" } }]
```

🤖 Generated with [Claude Code](https://claude.ai/code)