### PR TITLE
fix: capture typed prefix before paste in PasteInterceptor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3425,12 +3425,23 @@ async function main() {
   const onLine = (line: string) => {
     if (rlClosed) return;
 
-    // Check if there's pending paste content (captured by PasteInterceptor)
-    const pastedContent = consumePendingPaste();
-    if (pastedContent !== null) {
-      // Combine typed content (before paste) with pasted content
+    // Check if there's pending paste data (captured by PasteInterceptor)
+    const pasteData = consumePendingPaste();
+
+    // Debug logging
+    if (logLevel >= LogLevel.DEBUG) {
+      logger.debug(`[onLine] line=${JSON.stringify(line)}, pasteData=${JSON.stringify(pasteData)}`);
+    }
+
+    if (pasteData !== null) {
+      // Use prefix (what was typed before paste) + paste content
       // e.g., user types "/command " then pastes "args" -> "/command args"
-      handleInput(line + pastedContent);
+      // The prefix is captured by paste interceptor since readline may not preserve it
+      const combined = pasteData.prefix + pasteData.content;
+      if (logLevel >= LogLevel.DEBUG) {
+        logger.debug(`[onLine] combined=${JSON.stringify(combined)}`);
+      }
+      handleInput(combined);
     } else {
       // Normal typed input
       handleInput(line);


### PR DESCRIPTION
## Summary
- Fixes bug where typing `/mcp ` then pasting `tool-name` would send only `tool-name` to the model
- PasteInterceptor now tracks `prefixBuffer` for content typed before paste
- `consumePendingPaste()` returns `{prefix, content}` instead of just string
- Reset prefix tracking when newlines are encountered

## Test plan
- [x] Run `pnpm test` - all 1480 tests pass
- [x] Run `pnpm build` - compiles without errors
- [x] Added tests for command prefix capture
- [x] Added tests for newline reset behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)