### PR TITLE
fix: use readline's line buffer for paste prefix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3422,22 +3422,31 @@ async function main() {
   // Paste detection via debouncing
   // When lines arrive rapidly (within debounce window), they're buffered
   // Line handler that checks for pasted content
+  const debugPaste = process.env.DEBUG_PASTE === '1';
   const onLine = (line: string) => {
     if (rlClosed) return;
 
     // Check if there's pending paste data (captured by PasteInterceptor)
     const pasteData = consumePendingPaste();
 
-    // Debug logging
+    // Debug logging (always show with DEBUG_PASTE=1)
+    if (debugPaste) {
+      // eslint-disable-next-line no-console
+      console.error(`[PASTE_DEBUG onLine] line=${JSON.stringify(line)}, pasteData=${JSON.stringify(pasteData)}`);
+    }
     if (logLevel >= LogLevel.DEBUG) {
       logger.debug(`[onLine] line=${JSON.stringify(line)}, pasteData=${JSON.stringify(pasteData)}`);
     }
 
     if (pasteData !== null) {
-      // Use prefix (what was typed before paste) + paste content
+      // Use readline's line (typed content) + paste content
       // e.g., user types "/command " then pastes "args" -> "/command args"
-      // The prefix is captured by paste interceptor since readline may not preserve it
-      const combined = pasteData.prefix + pasteData.content;
+      // Note: readline's line buffer has the typed content; pasteData.prefix is unreliable
+      const combined = line + pasteData.content;
+      if (debugPaste) {
+        // eslint-disable-next-line no-console
+        console.error(`[PASTE_DEBUG onLine] combined=${JSON.stringify(combined)}`);
+      }
       if (logLevel >= LogLevel.DEBUG) {
         logger.debug(`[onLine] combined=${JSON.stringify(combined)}`);
       }


### PR DESCRIPTION
## Summary
- Fixes paste bug where typed command prefix was lost when pasting arguments
- Uses readline's `line` parameter (which has the correct typed content) instead of `pasteData.prefix`
- Added `DEBUG_PASTE=1` environment variable for troubleshooting

## Root Cause
The PasteInterceptor's `prefixBuffer` wasn't reliably capturing characters typed before paste. Debug logging showed:
- `line="/mcp add supabase "` (correct - from readline)
- `pasteData.prefix=" "` (wrong - only had a space)

## Fix
Changed from `pasteData.prefix + pasteData.content` to `line + pasteData.content`.

## Test plan
- [x] Type `/mcp add supabase ` then paste `something` → should run `/mcp add supabase something`
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)