### PR TITLE
fix: lowercase provider name for spawned agents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2983,7 +2983,8 @@ Begin by analyzing the query and planning your research approach.`;
     repoRoot: process.cwd(),
     readline: rl,
     // Pass current provider/model so spawned agents inherit them
-    defaultProvider: provider.getName(),
+    // Provider names must be lowercase for createProvider()
+    defaultProvider: provider.getName().toLowerCase(),
     defaultModel: provider.getModel(),
     onPermissionRequest: async (workerId, confirmation) => {
       // Display worker context


### PR DESCRIPTION
## Summary

Fixes spawned readers/workers failing with:
```
Error: Unknown provider type: Ollama. Available: anthropic, openai, ollama, ...
```

`provider.getName()` returns capitalized names like "Ollama" but `createProvider()` expects lowercase like "ollama".

## Test plan

- [x] All 1540 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)