### PR TITLE
feat: token-based tool result budget with RAG caching

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1241,9 +1241,9 @@ ${contextToSummarize}`,
         });
       }
 
-      // Truncate old tool results to save context (using tier-based config)
+      // Truncate old tool results to save context (using tier-based token budget)
       truncateOldToolResults(this.messages, {
-        recentToolResultsToKeep: this.contextConfig.recentToolResultsToKeep,
+        toolResultsTokenBudget: this.contextConfig.toolResultsTokenBudget,
         toolResultTruncateThreshold: this.contextConfig.toolResultTruncateThreshold,
       });
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,8 +28,12 @@ export const AGENT_CONFIG = {
   RECENT_MESSAGES_TO_KEEP: 600,
   /** Truncate old tool results longer than this (characters) */
   TOOL_RESULT_TRUNCATE_THRESHOLD: 500000,
-  /** Keep this many recent tool result messages untruncated */
-  RECENT_TOOL_RESULTS_TO_KEEP: 20,
+  /**
+   * Tool result token budget is now tier-based (see context-config.ts).
+   * Small: 20%, Medium: 25%, Large: 30%, XLarge: 35% of context window.
+   * Truncated results are cached for retrieval via recall_result tool.
+   */
+  TOOL_RESULTS_TOKEN_BUDGET_PERCENT: 0.25,
   /** Truncate immediate tool results longer than this (characters) - helps smaller models */
   MAX_IMMEDIATE_TOOL_RESULT: 500000,
 } as const;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -21,6 +21,7 @@ export { ShellInfoTool } from './shell-info.js';
 export { PipelineTool } from './pipeline.js';
 export { GenerateDocsTool } from './generate-docs.js';
 export { PrintTreeTool } from './print-tree.js';
+export { RecallResultTool } from './recall-result.js';
 
 // Orchestration tools
 export {
@@ -77,6 +78,7 @@ import { ShellInfoTool } from './shell-info.js';
 import { PipelineTool } from './pipeline.js';
 import { GenerateDocsTool } from './generate-docs.js';
 import { PrintTreeTool } from './print-tree.js';
+import { RecallResultTool } from './recall-result.js';
 import {
   DelegateTaskTool,
   CheckWorkersTool,
@@ -139,6 +141,9 @@ export function registerDefaultTools(): void {
 
   // Documentation
   globalRegistry.register(new GenerateDocsTool());
+
+  // Context management
+  globalRegistry.register(new RecallResultTool());
 }
 
 /**

--- a/src/tools/recall-result.ts
+++ b/src/tools/recall-result.ts
@@ -1,0 +1,151 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { BaseTool } from './base.js';
+import type { ToolDefinition } from '../types.js';
+import {
+  getCachedResult,
+  listCachedResults,
+  hasCachedResult,
+} from '../utils/tool-result-cache.js';
+
+/**
+ * Tool for retrieving cached tool results that were truncated for context management.
+ * When tool results are too large, they are summarized and cached with an ID.
+ * This tool allows retrieval of the full content when needed.
+ */
+export class RecallResultTool extends BaseTool {
+  getDefinition(): ToolDefinition {
+    return {
+      name: 'recall_result',
+      description:
+        'Retrieve a previously truncated tool result by its cache ID. ' +
+        'When tool results are large, they are summarized with a cache ID like ' +
+        '"[read_file: 500 lines] (cached: read_file_abc123, ~2000 tokens)". ' +
+        'Use this tool with the cache ID to retrieve the full content. ' +
+        'You can also list available cached results.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          cache_id: {
+            type: 'string',
+            description:
+              'The cache ID to retrieve (e.g., "read_file_abc123"). ' +
+              'Found in truncated result summaries after "cached:".',
+          },
+          action: {
+            type: 'string',
+            enum: ['get', 'list', 'check'],
+            description:
+              'Action to perform: "get" retrieves full content (default), ' +
+              '"list" shows available cached results, ' +
+              '"check" verifies if a cache ID exists.',
+          },
+        },
+        required: [],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>): Promise<string> {
+    const action = (input.action as string) || 'get';
+    const cacheId = input.cache_id as string | undefined;
+
+    switch (action) {
+      case 'list':
+        return this.listCached();
+
+      case 'check':
+        if (!cacheId) {
+          return 'Error: cache_id is required for check action';
+        }
+        return this.checkCached(cacheId);
+
+      case 'get':
+      default:
+        if (!cacheId) {
+          return 'Error: cache_id is required to retrieve a cached result. Use action="list" to see available results.';
+        }
+        return this.getCached(cacheId);
+    }
+  }
+
+  private getCached(cacheId: string): string {
+    const result = getCachedResult(cacheId);
+
+    if (!result) {
+      return `Error: No cached result found for ID "${cacheId}". It may have expired (24h limit) or been cleaned up.`;
+    }
+
+    const header = [
+      `=== Cached Result: ${cacheId} ===`,
+      `Tool: ${result.toolName}`,
+      `Cached: ${new Date(result.cachedAt).toISOString()}`,
+      `Tokens: ~${result.estimatedTokens}`,
+      result.isError ? 'Status: ERROR' : '',
+      '---',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    return `${header}\n${result.content}`;
+  }
+
+  private listCached(): string {
+    const results = listCachedResults();
+
+    if (results.length === 0) {
+      return 'No cached results available.';
+    }
+
+    const lines = ['Available cached results:', ''];
+
+    for (const { id, metadata } of results.slice(0, 20)) {
+      const age = this.formatAge(Date.now() - metadata.cachedAt);
+      const size = this.formatSize(metadata.contentLength);
+      lines.push(
+        `  ${id}`,
+        `    Tool: ${metadata.toolName}, Size: ${size}, Tokens: ~${metadata.estimatedTokens}, Age: ${age}`,
+        `    Summary: ${metadata.summary.slice(0, 100)}${metadata.summary.length > 100 ? '...' : ''}`,
+        ''
+      );
+    }
+
+    if (results.length > 20) {
+      lines.push(`  ... and ${results.length - 20} more`);
+    }
+
+    return lines.join('\n');
+  }
+
+  private checkCached(cacheId: string): string {
+    if (hasCachedResult(cacheId)) {
+      const result = getCachedResult(cacheId);
+      if (result) {
+        return (
+          `Cache ID "${cacheId}" exists.\n` +
+          `Tool: ${result.toolName}\n` +
+          `Size: ${this.formatSize(result.content.length)}\n` +
+          `Tokens: ~${result.estimatedTokens}\n` +
+          `Age: ${this.formatAge(Date.now() - result.cachedAt)}`
+        );
+      }
+    }
+    return `Cache ID "${cacheId}" not found.`;
+  }
+
+  private formatAge(ms: number): string {
+    const minutes = Math.floor(ms / 60000);
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ${minutes % 60}m`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ${hours % 24}h`;
+  }
+
+  private formatSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes}B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -37,7 +37,22 @@ export {
 export {
   summarizeToolResult,
   truncateOldToolResults,
+  isToolResultTruncated,
+  extractCacheId,
+  type ToolResultConfig,
 } from './tool-result-utils.js';
+
+// Tool result caching for RAG-like retrieval
+export {
+  generateCacheId,
+  cacheToolResult,
+  getCachedResult,
+  hasCachedResult,
+  listCachedResults,
+  cleanupCache,
+  clearCache,
+  type CachedToolResult,
+} from './tool-result-cache.js';
 
 // Image parsing utilities
 export {

--- a/src/utils/tool-result-cache.ts
+++ b/src/utils/tool-result-cache.ts
@@ -1,0 +1,242 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Tool Result Cache
+ *
+ * Stores full tool results when they are truncated for context management.
+ * Allows retrieval via hash/ID for RAG-like lookup.
+ */
+
+import { createHash } from 'crypto';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, statSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+/**
+ * Cached tool result entry.
+ */
+export interface CachedToolResult {
+  /** Unique hash ID for lookup */
+  id: string;
+  /** Tool name that produced this result */
+  toolName: string;
+  /** Tool input (for context) */
+  toolInput?: Record<string, unknown>;
+  /** Full result content */
+  content: string;
+  /** Whether result was an error */
+  isError: boolean;
+  /** Timestamp when cached */
+  cachedAt: number;
+  /** Summary that was used in place of full content */
+  summary: string;
+  /** Token estimate of full content */
+  estimatedTokens: number;
+}
+
+/**
+ * Cache metadata stored alongside content.
+ */
+interface CacheMetadata {
+  toolName: string;
+  toolInput?: Record<string, unknown>;
+  isError: boolean;
+  cachedAt: number;
+  summary: string;
+  estimatedTokens: number;
+  contentLength: number;
+}
+
+const CACHE_DIR = join(homedir(), '.codi', 'tool-cache');
+const MAX_CACHE_SIZE_MB = 100; // Maximum cache size in MB
+const MAX_CACHE_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/**
+ * Ensure cache directory exists.
+ */
+function ensureCacheDir(): void {
+  if (!existsSync(CACHE_DIR)) {
+    mkdirSync(CACHE_DIR, { recursive: true });
+  }
+}
+
+/**
+ * Generate a hash ID for content.
+ */
+export function generateCacheId(toolName: string, content: string): string {
+  const hash = createHash('sha256')
+    .update(toolName)
+    .update(content)
+    .digest('hex')
+    .slice(0, 12); // Short hash for readability
+  return `${toolName.slice(0, 10)}_${hash}`;
+}
+
+/**
+ * Store a tool result in the cache.
+ */
+export function cacheToolResult(
+  toolName: string,
+  content: string,
+  summary: string,
+  estimatedTokens: number,
+  isError: boolean = false,
+  toolInput?: Record<string, unknown>
+): string {
+  ensureCacheDir();
+
+  const id = generateCacheId(toolName, content);
+  const contentPath = join(CACHE_DIR, `${id}.content`);
+  const metaPath = join(CACHE_DIR, `${id}.meta.json`);
+
+  // Write content
+  writeFileSync(contentPath, content, 'utf-8');
+
+  // Write metadata
+  const metadata: CacheMetadata = {
+    toolName,
+    toolInput,
+    isError,
+    cachedAt: Date.now(),
+    summary,
+    estimatedTokens,
+    contentLength: content.length,
+  };
+  writeFileSync(metaPath, JSON.stringify(metadata, null, 2), 'utf-8');
+
+  return id;
+}
+
+/**
+ * Retrieve a cached tool result by ID.
+ */
+export function getCachedResult(id: string): CachedToolResult | null {
+  const contentPath = join(CACHE_DIR, `${id}.content`);
+  const metaPath = join(CACHE_DIR, `${id}.meta.json`);
+
+  if (!existsSync(contentPath) || !existsSync(metaPath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(contentPath, 'utf-8');
+    const metadata: CacheMetadata = JSON.parse(readFileSync(metaPath, 'utf-8'));
+
+    return {
+      id,
+      toolName: metadata.toolName,
+      toolInput: metadata.toolInput,
+      content,
+      isError: metadata.isError,
+      cachedAt: metadata.cachedAt,
+      summary: metadata.summary,
+      estimatedTokens: metadata.estimatedTokens,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a cached result exists.
+ */
+export function hasCachedResult(id: string): boolean {
+  const contentPath = join(CACHE_DIR, `${id}.content`);
+  return existsSync(contentPath);
+}
+
+/**
+ * List all cached result IDs with metadata.
+ */
+export function listCachedResults(): Array<{ id: string; metadata: CacheMetadata }> {
+  ensureCacheDir();
+
+  const results: Array<{ id: string; metadata: CacheMetadata }> = [];
+  const files = readdirSync(CACHE_DIR);
+
+  for (const file of files) {
+    if (file.endsWith('.meta.json')) {
+      const id = file.replace('.meta.json', '');
+      try {
+        const metaPath = join(CACHE_DIR, file);
+        const metadata: CacheMetadata = JSON.parse(readFileSync(metaPath, 'utf-8'));
+        results.push({ id, metadata });
+      } catch {
+        // Skip invalid files
+      }
+    }
+  }
+
+  // Sort by cached time, newest first
+  results.sort((a, b) => b.metadata.cachedAt - a.metadata.cachedAt);
+  return results;
+}
+
+/**
+ * Clean up old cache entries.
+ */
+export function cleanupCache(): { removed: number; freedBytes: number } {
+  ensureCacheDir();
+
+  const now = Date.now();
+  let removed = 0;
+  let freedBytes = 0;
+
+  const files = readdirSync(CACHE_DIR);
+
+  for (const file of files) {
+    if (file.endsWith('.meta.json')) {
+      const id = file.replace('.meta.json', '');
+      const metaPath = join(CACHE_DIR, file);
+      const contentPath = join(CACHE_DIR, `${id}.content`);
+
+      try {
+        const metadata: CacheMetadata = JSON.parse(readFileSync(metaPath, 'utf-8'));
+
+        // Remove old entries
+        if (now - metadata.cachedAt > MAX_CACHE_AGE_MS) {
+          if (existsSync(contentPath)) {
+            freedBytes += statSync(contentPath).size;
+            unlinkSync(contentPath);
+          }
+          freedBytes += statSync(metaPath).size;
+          unlinkSync(metaPath);
+          removed++;
+        }
+      } catch {
+        // Remove invalid files
+        try {
+          if (existsSync(contentPath)) unlinkSync(contentPath);
+          if (existsSync(metaPath)) unlinkSync(metaPath);
+          removed++;
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    }
+  }
+
+  return { removed, freedBytes };
+}
+
+/**
+ * Clear all cached results.
+ */
+export function clearCache(): number {
+  ensureCacheDir();
+
+  let removed = 0;
+  const files = readdirSync(CACHE_DIR);
+
+  for (const file of files) {
+    try {
+      unlinkSync(join(CACHE_DIR, file));
+      removed++;
+    } catch {
+      // Ignore errors
+    }
+  }
+
+  return removed;
+}

--- a/src/utils/tool-result-utils.ts
+++ b/src/utils/tool-result-utils.ts
@@ -3,107 +3,213 @@
 
 /**
  * Tool result processing utilities.
- * Extracted from agent.ts for reusability.
+ * Handles truncation and caching of tool results for context management.
  */
 
-import type { Message } from '../types.js';
-import { AGENT_CONFIG } from '../constants.js';
+import type { Message, ContentBlock } from '../types.js';
+import { estimateTokens } from './token-counter.js';
+import { cacheToolResult, generateCacheId } from './tool-result-cache.js';
 
 /**
  * Configuration for tool result truncation.
  */
 export interface ToolResultConfig {
-  /** Number of recent tool results to keep untruncated */
-  recentToolResultsToKeep: number;
-  /** Truncate tool results longer than this (characters) */
+  /** Token budget for all tool results combined */
+  toolResultsTokenBudget: number;
+  /** Truncate individual tool results longer than this (characters) */
   toolResultTruncateThreshold: number;
 }
 
 /**
  * Create a short summary of a tool result for truncation.
+ * Includes a cache ID for later retrieval.
  */
-export function summarizeToolResult(toolName: string, content: string, isError: boolean): string {
+export function summarizeToolResult(
+  toolName: string,
+  content: string,
+  isError: boolean,
+  cacheId?: string
+): string {
   const lines = content.split('\n').length;
   const chars = content.length;
+  const tokens = estimateTokens(content);
+
+  // Build base summary based on tool type
+  let baseSummary: string;
 
   if (isError) {
     // Keep first line of error for context
     const firstLine = content.split('\n')[0].slice(0, 100);
-    return `[${toolName} ERROR: ${firstLine}...]`;
+    baseSummary = `ERROR: ${firstLine}...`;
+  } else {
+    // Create summary based on tool type
+    switch (toolName) {
+      case 'read_file':
+      case 'list_directory':
+        baseSummary = `${lines} lines, ${chars} chars`;
+        break;
+      case 'glob':
+      case 'grep': {
+        const matchCount = content.split('\n').filter(l => l.trim()).length;
+        baseSummary = `${matchCount} matches`;
+        break;
+      }
+      case 'bash': {
+        const preview = content.slice(0, 80).replace(/\n/g, ' ').trim();
+        baseSummary = `${preview}${chars > 80 ? '...' : ''} (${lines} lines)`;
+        break;
+      }
+      case 'write_file':
+      case 'edit_file':
+      case 'insert_line':
+      case 'patch_file':
+        baseSummary = 'success';
+        break;
+      default:
+        baseSummary = `${lines} lines, ${chars} chars`;
+    }
   }
 
-  // Create summary based on tool type
-  switch (toolName) {
-    case 'read_file':
-    case 'list_directory':
-      return `[${toolName}: ${lines} lines, ${chars} chars]`;
-    case 'glob':
-    case 'grep': {
-      const matchCount = content.split('\n').filter(l => l.trim()).length;
-      return `[${toolName}: ${matchCount} matches]`;
+  // Include cache ID for retrieval if available
+  if (cacheId) {
+    return `[${toolName}: ${baseSummary}] (cached: ${cacheId}, ~${tokens} tokens)`;
+  }
+
+  return `[${toolName}: ${baseSummary}]`;
+}
+
+/**
+ * Tool result info extracted from message.
+ */
+interface ToolResultInfo {
+  index: number;
+  messageIndex: number;
+  toolName: string;
+  content: string;
+  isError: boolean;
+  tokens: number;
+}
+
+/**
+ * Get all tool results from message history with token estimates.
+ */
+function getToolResultsInfo(messages: Message[]): ToolResultInfo[] {
+  const results: ToolResultInfo[] = [];
+
+  for (let msgIdx = 0; msgIdx < messages.length; msgIdx++) {
+    const msg = messages[msgIdx];
+    if (typeof msg.content === 'string') continue;
+
+    for (let blockIdx = 0; blockIdx < msg.content.length; blockIdx++) {
+      const block = msg.content[blockIdx];
+      if (block.type !== 'tool_result') continue;
+
+      const content = block.content || '';
+      results.push({
+        index: blockIdx,
+        messageIndex: msgIdx,
+        toolName: block.name || 'unknown',
+        content,
+        isError: !!block.is_error,
+        tokens: estimateTokens(content),
+      });
     }
-    case 'bash': {
-      const preview = content.slice(0, 100).replace(/\n/g, ' ');
-      return `[${toolName}: ${preview}${chars > 100 ? '...' : ''} (${lines} lines)]`;
+  }
+
+  return results;
+}
+
+/**
+ * Truncate old tool results to fit within token budget.
+ * Caches truncated results for later retrieval via RAG.
+ *
+ * Strategy:
+ * 1. Calculate total tokens used by tool results
+ * 2. If over budget, truncate oldest results first
+ * 3. Cache full content and replace with summary + cache ID
+ *
+ * @param messages - Message history to process (mutated in place)
+ * @param config - Token budget configuration
+ */
+export function truncateOldToolResults(messages: Message[], config: ToolResultConfig): void {
+  const toolResults = getToolResultsInfo(messages);
+  if (toolResults.length === 0) return;
+
+  // Calculate total tokens used by tool results
+  let totalTokens = toolResults.reduce((sum, r) => sum + r.tokens, 0);
+
+  // If within budget, nothing to do
+  if (totalTokens <= config.toolResultsTokenBudget) {
+    return;
+  }
+
+  // Process from oldest to newest, truncating until within budget
+  // Keep at least the last 2 results intact for immediate context
+  const minKeepIntact = Math.min(2, toolResults.length);
+  const candidatesForTruncation = toolResults.slice(0, -minKeepIntact);
+
+  for (const result of candidatesForTruncation) {
+    // Skip if already truncated (summary format)
+    if (result.content.startsWith('[') && result.content.includes('cached:')) {
+      continue;
     }
-    case 'write_file':
-    case 'edit_file':
-    case 'insert_line':
-    case 'patch_file':
-      return `[${toolName}: success]`;
-    default:
-      return `[${toolName}: ${lines} lines, ${chars} chars]`;
+
+    // Skip small results (not worth truncating)
+    if (result.content.length < config.toolResultTruncateThreshold / 10) {
+      continue;
+    }
+
+    // Cache the full result
+    const cacheId = generateCacheId(result.toolName, result.content);
+    const summary = summarizeToolResult(
+      result.toolName,
+      result.content,
+      result.isError,
+      cacheId
+    );
+
+    // Store in cache
+    cacheToolResult(
+      result.toolName,
+      result.content,
+      summary,
+      result.tokens,
+      result.isError
+    );
+
+    // Update the message with summary
+    const msg = messages[result.messageIndex];
+    if (typeof msg.content !== 'string') {
+      const block = msg.content[result.index] as ContentBlock;
+      if (block.type === 'tool_result') {
+        // Calculate token savings
+        const oldTokens = result.tokens;
+        const newTokens = estimateTokens(summary);
+        totalTokens -= (oldTokens - newTokens);
+
+        // Replace content with summary
+        (block as { content: string }).content = summary;
+      }
+    }
+
+    // Check if we're now within budget
+    if (totalTokens <= config.toolResultsTokenBudget) {
+      break;
+    }
   }
 }
 
 /**
- * Truncate old tool results in message history to save context.
- * Keeps recent tool results intact, truncates older ones to summaries.
- *
- * @param messages - Message history to process
- * @param config - Optional config (defaults to AGENT_CONFIG for backwards compatibility)
+ * Check if a tool result has been truncated (is a summary).
  */
-export function truncateOldToolResults(messages: Message[], config?: ToolResultConfig): void {
-  // Use provided config or fall back to static AGENT_CONFIG
-  const cfg = config ?? {
-    recentToolResultsToKeep: AGENT_CONFIG.RECENT_TOOL_RESULTS_TO_KEEP,
-    toolResultTruncateThreshold: AGENT_CONFIG.TOOL_RESULT_TRUNCATE_THRESHOLD,
-  };
+export function isToolResultTruncated(content: string): boolean {
+  return content.startsWith('[') && content.includes('cached:');
+}
 
-  // Find indices of messages containing tool_result blocks
-  const toolResultIndices: number[] = [];
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i];
-    if (typeof msg.content !== 'string') {
-      const hasToolResult = msg.content.some(block => block.type === 'tool_result');
-      if (hasToolResult) {
-        toolResultIndices.push(i);
-      }
-    }
-  }
-
-  // Keep recent tool results, truncate older ones
-  const indicesToTruncate = toolResultIndices.slice(0, -cfg.recentToolResultsToKeep);
-
-  for (const idx of indicesToTruncate) {
-    const msg = messages[idx];
-    if (typeof msg.content === 'string') continue;
-
-    msg.content = msg.content.map(block => {
-      if (block.type !== 'tool_result') return block;
-      if (!block.content || block.content.length <= cfg.toolResultTruncateThreshold) return block;
-
-      // Truncate to summary
-      const summary = summarizeToolResult(
-        block.name || 'tool',
-        block.content,
-        !!block.is_error
-      );
-
-      return {
-        ...block,
-        content: summary,
-      };
-    });
-  }
+/**
+ * Extract cache ID from a truncated tool result summary.
+ */
+export function extractCacheId(summary: string): string | null {
+  const match = summary.match(/cached:\s*([^,)]+)/);
+  return match ? match[1].trim() : null;
 }

--- a/tests/context-config.test.ts
+++ b/tests/context-config.test.ts
@@ -136,7 +136,7 @@ describe('context-config', () => {
 
       // Larger tiers should have larger limits
       expect(large.toolResultTruncateThreshold).toBeGreaterThan(small.toolResultTruncateThreshold);
-      expect(large.recentToolResultsToKeep).toBeGreaterThan(small.recentToolResultsToKeep);
+      expect(large.toolResultsTokenBudget).toBeGreaterThan(small.toolResultsTokenBudget);
       expect(large.maxImmediateToolResult).toBeGreaterThan(small.maxImmediateToolResult);
     });
 
@@ -161,7 +161,7 @@ describe('context-config', () => {
       expect(legacy).toHaveProperty('MIN_VIABLE_CONTEXT');
       expect(legacy).toHaveProperty('RECENT_MESSAGES_TO_KEEP');
       expect(legacy).toHaveProperty('TOOL_RESULT_TRUNCATE_THRESHOLD');
-      expect(legacy).toHaveProperty('RECENT_TOOL_RESULTS_TO_KEEP');
+      expect(legacy).toHaveProperty('TOOL_RESULTS_TOKEN_BUDGET');
       expect(legacy).toHaveProperty('MAX_IMMEDIATE_TOOL_RESULT');
     });
 

--- a/tests/recall-result.test.ts
+++ b/tests/recall-result.test.ts
@@ -1,0 +1,145 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RecallResultTool } from '../src/tools/recall-result.js';
+import { cacheToolResult, clearCache } from '../src/utils/tool-result-cache.js';
+
+describe('RecallResultTool', () => {
+  let tool: RecallResultTool;
+
+  beforeEach(() => {
+    tool = new RecallResultTool();
+  });
+
+  describe('getDefinition', () => {
+    it('returns valid tool definition', () => {
+      const def = tool.getDefinition();
+
+      expect(def.name).toBe('recall_result');
+      expect(def.description).toBeTruthy();
+      expect(def.input_schema).toBeDefined();
+      expect(def.input_schema.type).toBe('object');
+    });
+
+    it('defines cache_id and action parameters', () => {
+      const def = tool.getDefinition();
+      const props = def.input_schema.properties as Record<string, unknown>;
+
+      expect(props).toHaveProperty('cache_id');
+      expect(props).toHaveProperty('action');
+    });
+
+    it('action parameter has valid enum values', () => {
+      const def = tool.getDefinition();
+      const props = def.input_schema.properties as Record<string, { enum?: string[] }>;
+
+      expect(props.action.enum).toContain('get');
+      expect(props.action.enum).toContain('list');
+      expect(props.action.enum).toContain('check');
+    });
+  });
+
+  describe('execute - get action', () => {
+    it('retrieves cached result by ID', async () => {
+      const content = 'This is the full file content\nLine 2\nLine 3';
+      const id = cacheToolResult('read_file', content, '[read_file: 3 lines]', 25, false);
+
+      const result = await tool.execute({ cache_id: id });
+
+      expect(result).toContain('Cached Result:');
+      expect(result).toContain(id);
+      expect(result).toContain(content);
+      expect(result).toContain('Tool: read_file');
+    });
+
+    it('returns error for missing cache_id', async () => {
+      const result = await tool.execute({});
+
+      expect(result).toContain('Error:');
+      expect(result).toContain('cache_id is required');
+    });
+
+    it('returns error for non-existent ID', async () => {
+      const result = await tool.execute({ cache_id: 'fake_id_12345' });
+
+      expect(result).toContain('Error:');
+      expect(result).toContain('No cached result found');
+    });
+
+    it('shows error status for error results', async () => {
+      const id = cacheToolResult('bash', 'Command failed', '[bash: ERROR]', 10, true);
+
+      const result = await tool.execute({ cache_id: id });
+
+      expect(result).toContain('Status: ERROR');
+    });
+  });
+
+  describe('execute - list action', () => {
+    it('lists available cached results', async () => {
+      // Add some results
+      cacheToolResult('read_file', 'content1', 'summary1', 10, false);
+      cacheToolResult('grep', 'content2', 'summary2', 20, false);
+
+      const result = await tool.execute({ action: 'list' });
+
+      expect(result).toContain('Available cached results');
+      expect(result).toContain('read_file');
+      expect(result).toContain('grep');
+    });
+
+    it('shows metadata for each result', async () => {
+      cacheToolResult('test_tool', 'test content', 'test summary', 50, false);
+
+      const result = await tool.execute({ action: 'list' });
+
+      expect(result).toContain('Tool: test_tool');
+      expect(result).toContain('Tokens: ~50');
+    });
+
+    it('handles empty cache', async () => {
+      clearCache();
+
+      const result = await tool.execute({ action: 'list' });
+
+      // Should either show "No cached results" or an empty list
+      expect(result).toBeTruthy();
+    });
+  });
+
+  describe('execute - check action', () => {
+    it('confirms existing cache ID', async () => {
+      const id = cacheToolResult('read_file', 'content', 'summary', 10, false);
+
+      const result = await tool.execute({ action: 'check', cache_id: id });
+
+      expect(result).toContain('exists');
+      expect(result).toContain('read_file');
+    });
+
+    it('reports missing cache ID', async () => {
+      const result = await tool.execute({ action: 'check', cache_id: 'nonexistent_id' });
+
+      expect(result).toContain('not found');
+    });
+
+    it('returns error without cache_id', async () => {
+      const result = await tool.execute({ action: 'check' });
+
+      expect(result).toContain('Error:');
+      expect(result).toContain('cache_id is required');
+    });
+  });
+
+  describe('execute - default action', () => {
+    it('defaults to get action', async () => {
+      const id = cacheToolResult('read_file', 'content', 'summary', 10, false);
+
+      const result = await tool.execute({ cache_id: id });
+
+      expect(result).toContain('Cached Result:');
+      expect(result).toContain('content');
+    });
+  });
+});

--- a/tests/tool-result-cache.test.ts
+++ b/tests/tool-result-cache.test.ts
@@ -1,0 +1,204 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  generateCacheId,
+  cacheToolResult,
+  getCachedResult,
+  hasCachedResult,
+  listCachedResults,
+  cleanupCache,
+  clearCache,
+} from '../src/utils/tool-result-cache.js';
+
+describe('tool-result-cache', () => {
+  describe('generateCacheId', () => {
+    it('generates consistent IDs for same input', () => {
+      const id1 = generateCacheId('read_file', 'content');
+      const id2 = generateCacheId('read_file', 'content');
+      expect(id1).toBe(id2);
+    });
+
+    it('generates different IDs for different content', () => {
+      const id1 = generateCacheId('read_file', 'content1');
+      const id2 = generateCacheId('read_file', 'content2');
+      expect(id1).not.toBe(id2);
+    });
+
+    it('generates different IDs for different tool names', () => {
+      const id1 = generateCacheId('read_file', 'content');
+      const id2 = generateCacheId('glob', 'content');
+      expect(id1).not.toBe(id2);
+    });
+
+    it('includes tool name prefix in ID', () => {
+      const id = generateCacheId('read_file', 'content');
+      expect(id).toMatch(/^read_file_/);
+    });
+
+    it('truncates long tool names', () => {
+      const id = generateCacheId('very_long_tool_name_here', 'content');
+      expect(id).toMatch(/^very_long_/);
+    });
+  });
+
+  describe('cacheToolResult', () => {
+    it('returns a cache ID', () => {
+      const id = cacheToolResult(
+        'read_file',
+        'file content here',
+        '[read_file: 3 lines]',
+        100,
+        false
+      );
+      expect(id).toBeTruthy();
+      expect(typeof id).toBe('string');
+    });
+
+    it('stores result that can be retrieved', () => {
+      const content = 'test file content\nline 2\nline 3';
+      const id = cacheToolResult(
+        'read_file',
+        content,
+        '[read_file: 3 lines]',
+        75,
+        false
+      );
+
+      const result = getCachedResult(id);
+      expect(result).not.toBeNull();
+      expect(result!.content).toBe(content);
+      expect(result!.toolName).toBe('read_file');
+      expect(result!.isError).toBe(false);
+      expect(result!.estimatedTokens).toBe(75);
+    });
+
+    it('stores error results correctly', () => {
+      const id = cacheToolResult(
+        'bash',
+        'Command failed: exit code 1',
+        '[bash: ERROR]',
+        20,
+        true
+      );
+
+      const result = getCachedResult(id);
+      expect(result!.isError).toBe(true);
+    });
+
+    it('stores tool input when provided', () => {
+      const id = cacheToolResult(
+        'read_file',
+        'content',
+        'summary',
+        10,
+        false,
+        { path: '/test/file.txt' }
+      );
+
+      const result = getCachedResult(id);
+      expect(result!.toolInput).toEqual({ path: '/test/file.txt' });
+    });
+  });
+
+  describe('getCachedResult', () => {
+    it('returns null for non-existent ID', () => {
+      const result = getCachedResult('nonexistent_id_12345');
+      expect(result).toBeNull();
+    });
+
+    it('returns complete result object', () => {
+      const id = cacheToolResult(
+        'grep',
+        'match1\nmatch2',
+        '[grep: 2 matches]',
+        50,
+        false
+      );
+
+      const result = getCachedResult(id);
+      expect(result).toMatchObject({
+        id,
+        toolName: 'grep',
+        content: 'match1\nmatch2',
+        isError: false,
+        summary: '[grep: 2 matches]',
+        estimatedTokens: 50,
+      });
+      expect(result!.cachedAt).toBeGreaterThan(0);
+    });
+  });
+
+  describe('hasCachedResult', () => {
+    it('returns true for existing result', () => {
+      const id = cacheToolResult('test', 'content', 'summary', 10, false);
+      expect(hasCachedResult(id)).toBe(true);
+    });
+
+    it('returns false for non-existent result', () => {
+      expect(hasCachedResult('fake_id_999')).toBe(false);
+    });
+  });
+
+  describe('listCachedResults', () => {
+    it('returns array of cached results', () => {
+      // Cache a few results
+      cacheToolResult('tool1', 'content1', 'summary1', 10, false);
+      cacheToolResult('tool2', 'content2', 'summary2', 20, false);
+
+      const results = listCachedResults();
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('includes metadata for each result', () => {
+      const id = cacheToolResult('test_tool', 'test content', 'test summary', 15, false);
+
+      const results = listCachedResults();
+      const entry = results.find(r => r.id === id);
+
+      expect(entry).toBeDefined();
+      expect(entry!.metadata.toolName).toBe('test_tool');
+      expect(entry!.metadata.summary).toBe('test summary');
+      expect(entry!.metadata.estimatedTokens).toBe(15);
+    });
+
+    it('sorts by cached time, newest first', () => {
+      // Add with slight delay to ensure different timestamps
+      const id1 = cacheToolResult('first', 'c1', 's1', 10, false);
+      const id2 = cacheToolResult('second', 'c2', 's2', 10, false);
+
+      const results = listCachedResults();
+      const idx1 = results.findIndex(r => r.id === id1);
+      const idx2 = results.findIndex(r => r.id === id2);
+
+      // Second should come before first (newer first)
+      expect(idx2).toBeLessThan(idx1);
+    });
+  });
+
+  describe('cleanupCache', () => {
+    it('returns cleanup statistics', () => {
+      const stats = cleanupCache();
+      expect(stats).toHaveProperty('removed');
+      expect(stats).toHaveProperty('freedBytes');
+      expect(typeof stats.removed).toBe('number');
+      expect(typeof stats.freedBytes).toBe('number');
+    });
+  });
+
+  describe('clearCache', () => {
+    it('removes all cached results', () => {
+      // Add some results
+      cacheToolResult('t1', 'c1', 's1', 10, false);
+      cacheToolResult('t2', 'c2', 's2', 10, false);
+
+      const removed = clearCache();
+      expect(removed).toBeGreaterThanOrEqual(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replace count-based tool result management with token budget approach (20-35% of context window by tier)
- Add caching for truncated tool results with hash-based IDs for later retrieval
- Add new `recall_result` tool for retrieving cached truncated content

## Changes
- `src/context-config.ts` - Added `toolResultsTokenBudgetPercent` to context tiers
- `src/utils/tool-result-cache.ts` - New file for caching truncated results to disk
- `src/utils/tool-result-utils.ts` - Rewritten to use token budget + caching
- `src/tools/recall-result.ts` - New tool for retrieving cached results
- `src/agent.ts` - Updated to use new config format
- `tests/tool-result-cache.test.ts` - 18 tests for cache functionality
- `tests/recall-result.test.ts` - 14 tests for recall tool
- Existing tests updated to match new API

## Test plan
- [x] All existing tests pass
- [x] New tests for tool-result-cache.ts (18 tests)
- [x] New tests for recall-result.ts (14 tests)
- [x] Total: 1577 tests passing
- [ ] Manual testing of recall_result tool with large file reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)