### PR TITLE
fix: add get_context_status and recall_result to system prompt tool list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -458,6 +458,10 @@ Use **recall_result** to retrieve full content:
 - **get_inheritance**: Show class hierarchy (params: name, direction)
 - **get_call_graph**: Show function callers (params: name, file)
 
+### Context Management
+- **get_context_status**: Check token budget usage and status (params: include_cached)
+- **recall_result**: Retrieve truncated/cached tool results (params: cache_id, action)
+
 ### Other
 - **bash**: Execute shell commands (params: command, cwd)
 - **run_tests**: Run project tests (params: command, filter, timeout)


### PR DESCRIPTION
## Summary

The `get_context_status` and `recall_result` tools were registered in the tool registry but not documented in the hardcoded "Available Tools" section of the system prompt. This meant the LLM model didn't know these tools existed.

## Changes

Added a new "Context Management" section to the Available Tools documentation:

```
### Context Management
- **get_context_status**: Check token budget usage and status (params: include_cached)
- **recall_result**: Retrieve truncated/cached tool results (params: cache_id, action)
```

## Test plan
- [x] Build passes
- [x] All 1590 tests pass
- [x] Verified fix appears in compiled output

🤖 Generated with [Claude Code](https://claude.ai/code)