### PR TITLE
fix: add delay to flaky timestamp test in tool-result-cache

### DIFF
--- a/tests/tool-result-cache.test.ts
+++ b/tests/tool-result-cache.test.ts
@@ -167,9 +167,10 @@ describe('tool-result-cache', () => {
       expect(entry!.metadata.estimatedTokens).toBe(15);
     });
 
-    it('sorts by cached time, newest first', () => {
+    it('sorts by cached time, newest first', async () => {
       // Add with slight delay to ensure different timestamps
       const id1 = cacheToolResult('first', 'c1', 's1', 10, false);
+      await new Promise(resolve => setTimeout(resolve, 5)); // Ensure different timestamp
       const id2 = cacheToolResult('second', 'c2', 's2', 10, false);
 
       const results = listCachedResults();


### PR DESCRIPTION
## Summary

Fixed a flaky test that was checking sort order by cached time. Both items were being cached in the same millisecond, making the order non-deterministic.

## Changes

Added a 5ms delay between caching the two items to ensure different timestamps.

## Test plan
- [x] Test passes consistently now
- [x] Full test suite passes (1590 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)