### PR TITLE
test: add unit tests for command modules

### DIFF
--- a/tests/compact-commands.test.ts
+++ b/tests/compact-commands.test.ts
@@ -1,0 +1,253 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { compactCommand, registerCompactCommands } from '../src/commands/compact-commands.js';
+import type { CommandContext } from '../src/commands/index.js';
+import type { Agent } from '../src/agent.js';
+
+// Mock the compression module
+vi.mock('../src/compression.js', () => ({
+  compressContext: vi.fn().mockReturnValue({
+    messages: [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there!' },
+    ],
+    entities: new Map([['__E1__', 'TypeScript']]),
+    originalSize: 100,
+    compressedSize: 80,
+  }),
+  generateEntityLegend: vi.fn().mockReturnValue('__E1__ = TypeScript'),
+  getCompressionStats: vi.fn().mockReturnValue({
+    originalChars: 100,
+    compressedChars: 80,
+    entitiesFound: 1,
+    savingsPercent: 20,
+  }),
+}));
+
+// Mock the commands/index module
+vi.mock('../src/commands/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/commands/index.js')>('../src/commands/index.js');
+  return {
+    ...actual,
+    registerCommand: vi.fn(),
+  };
+});
+
+import { registerCommand } from '../src/commands/index.js';
+
+// Create a mock agent
+function createMockAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    getContextInfo: vi.fn().mockReturnValue({
+      tokens: 5000,
+      messages: 10,
+      hasSummary: false,
+      compressionEnabled: false,
+      compression: null,
+    }),
+    forceCompact: vi.fn().mockResolvedValue({
+      before: 5000,
+      after: 3000,
+      summary: 'User discussed React hooks and TypeScript types.',
+    }),
+    setCompression: vi.fn(),
+    isCompressionEnabled: vi.fn().mockReturnValue(false),
+    getMessages: vi.fn().mockReturnValue([
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi!' },
+    ]),
+    ...overrides,
+  } as unknown as Agent;
+}
+
+const createContext = (agent?: Agent): CommandContext => ({
+  workingDirectory: '/test/project',
+  agent,
+});
+
+describe('Compact Commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('compactCommand', () => {
+    it('has correct name and aliases', () => {
+      expect(compactCommand.name).toBe('compact');
+      expect(compactCommand.aliases).toContain('summarize');
+      expect(compactCommand.aliases).toContain('compress');
+      expect(compactCommand.aliases).toContain('compression');
+    });
+
+    it('has taskType set to fast', () => {
+      expect(compactCommand.taskType).toBe('fast');
+    });
+
+    it('returns error when no agent is available', async () => {
+      const result = await compactCommand.execute('', createContext());
+      expect(result).toBe('COMPACT_ERROR:No agent available');
+    });
+
+    describe('status subcommand', () => {
+      it('shows status by default (no args)', async () => {
+        const agent = createMockAgent();
+        const result = await compactCommand.execute('', createContext(agent));
+
+        expect(result).toContain('COMPACT_STATUS:');
+        expect(agent.getContextInfo).toHaveBeenCalled();
+
+        const parsed = JSON.parse(result!.replace('COMPACT_STATUS:', ''));
+        expect(parsed).toHaveProperty('tokens', 5000);
+        expect(parsed).toHaveProperty('messages', 10);
+        expect(parsed).toHaveProperty('hasSummary', false);
+        expect(parsed).toHaveProperty('compression');
+      });
+
+      it('shows status with explicit status arg', async () => {
+        const agent = createMockAgent();
+        const result = await compactCommand.execute('status', createContext(agent));
+
+        expect(result).toContain('COMPACT_STATUS:');
+      });
+    });
+
+    describe('summarize subcommand', () => {
+      it('skips when not enough messages', async () => {
+        const agent = createMockAgent({
+          getContextInfo: vi.fn().mockReturnValue({
+            tokens: 1000,
+            messages: 4,
+            hasSummary: false,
+            compressionEnabled: false,
+            compression: null,
+          }),
+        });
+
+        const result = await compactCommand.execute('summarize', createContext(agent));
+
+        expect(result).toContain('COMPACT_SKIP:');
+        const parsed = JSON.parse(result!.replace('COMPACT_SKIP:', ''));
+        expect(parsed.reason).toContain('Not enough messages');
+      });
+
+      it('performs summarization when enough messages', async () => {
+        const agent = createMockAgent({
+          getContextInfo: vi.fn().mockReturnValue({
+            tokens: 5000,
+            messages: 10,
+            hasSummary: false,
+            compressionEnabled: false,
+            compression: null,
+          }),
+        });
+
+        const result = await compactCommand.execute('summarize', createContext(agent));
+
+        expect(result).toContain('COMPACT_SUCCESS:');
+        expect(agent.forceCompact).toHaveBeenCalled();
+
+        const parsed = JSON.parse(result!.replace('COMPACT_SUCCESS:', ''));
+        expect(parsed).toHaveProperty('before');
+        expect(parsed).toHaveProperty('after');
+        expect(parsed).toHaveProperty('tokensSaved', 2000);
+        expect(parsed.summary).toContain('React hooks');
+      });
+
+      it('forces summarization with --force flag', async () => {
+        const agent = createMockAgent({
+          getContextInfo: vi.fn().mockReturnValue({
+            tokens: 1000,
+            messages: 4,
+            hasSummary: false,
+            compressionEnabled: false,
+            compression: null,
+          }),
+        });
+
+        const result = await compactCommand.execute('summarize --force', createContext(agent));
+
+        expect(result).toContain('COMPACT_SUCCESS:');
+        expect(agent.forceCompact).toHaveBeenCalled();
+      });
+
+      it('handles summarization errors', async () => {
+        const agent = createMockAgent({
+          forceCompact: vi.fn().mockRejectedValue(new Error('Summarization failed')),
+        });
+
+        const result = await compactCommand.execute('summarize', createContext(agent));
+
+        expect(result).toContain('COMPACT_ERROR:');
+        expect(result).toContain('Summarization failed');
+      });
+    });
+
+    describe('compress subcommand', () => {
+      it('enables compression with "on"', async () => {
+        const agent = createMockAgent();
+        const result = await compactCommand.execute('compress on', createContext(agent));
+
+        expect(result).toBe('COMPRESS_TOGGLE:on');
+        expect(agent.setCompression).toHaveBeenCalledWith(true);
+      });
+
+      it('disables compression with "off"', async () => {
+        const agent = createMockAgent();
+        const result = await compactCommand.execute('compress off', createContext(agent));
+
+        expect(result).toBe('COMPRESS_TOGGLE:off');
+        expect(agent.setCompression).toHaveBeenCalledWith(false);
+      });
+
+      it('shows compression status when no messages', async () => {
+        const agent = createMockAgent({
+          getMessages: vi.fn().mockReturnValue([]),
+          getContextInfo: vi.fn().mockReturnValue({
+            compressionEnabled: false,
+            compression: null,
+          }),
+        });
+
+        const result = await compactCommand.execute('compress', createContext(agent));
+
+        expect(result).toContain('COMPRESS_STATUS:');
+      });
+
+      it('shows compression stats when messages exist', async () => {
+        const agent = createMockAgent();
+        const result = await compactCommand.execute('compress', createContext(agent));
+
+        expect(result).toContain('COMPRESS_STATS:');
+        const parsed = JSON.parse(result!.replace('COMPRESS_STATS:', ''));
+        expect(parsed).toHaveProperty('stats');
+        expect(parsed).toHaveProperty('enabled', false);
+      });
+
+      it('includes preview when --preview flag is used', async () => {
+        const agent = createMockAgent();
+        const result = await compactCommand.execute('compress --preview', createContext(agent));
+
+        expect(result).toContain('COMPRESS_STATS:');
+        const parsed = JSON.parse(result!.replace('COMPRESS_STATS:', ''));
+        expect(parsed).toHaveProperty('preview');
+        expect(parsed.preview).toHaveProperty('legend');
+      });
+    });
+
+    it('returns error for unknown subcommand', async () => {
+      const agent = createMockAgent();
+      const result = await compactCommand.execute('invalid', createContext(agent));
+
+      expect(result).toContain('COMPACT_ERROR:');
+      expect(result).toContain('Unknown subcommand');
+    });
+  });
+
+  describe('registerCompactCommands', () => {
+    it('registers the compact command', () => {
+      registerCompactCommands();
+      expect(registerCommand).toHaveBeenCalledWith(compactCommand);
+    });
+  });
+});

--- a/tests/memory-commands.test.ts
+++ b/tests/memory-commands.test.ts
@@ -1,0 +1,263 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  rememberCommand,
+  forgetCommand,
+  memoriesCommand,
+  profileCommand,
+  registerMemoryCommands,
+} from '../src/commands/memory-commands.js';
+import type { CommandContext } from '../src/commands/index.js';
+
+// Mock the memory module
+vi.mock('../src/memory.js', () => ({
+  loadProfile: vi.fn().mockReturnValue({
+    name: 'TestUser',
+    preferences: { language: 'TypeScript', style: 'functional' },
+    expertise: ['React', 'Node.js'],
+    avoid: ['jQuery'],
+  }),
+  updateProfile: vi.fn().mockReturnValue({
+    name: 'UpdatedUser',
+    preferences: { language: 'TypeScript' },
+  }),
+  loadMemories: vi.fn().mockReturnValue([
+    { content: 'Prefers dark mode', category: 'preferences', timestamp: '2024-01-15T10:00:00.000Z', source: 'user' },
+    { content: 'Uses pnpm', category: 'project', timestamp: '2024-01-15T11:00:00.000Z', source: 'user' },
+    { content: 'No category memory', timestamp: '2024-01-15T12:00:00.000Z', source: 'user' },
+  ]),
+  addMemory: vi.fn().mockReturnValue({
+    content: 'New memory content',
+    category: 'test',
+    timestamp: '2024-01-15T13:00:00.000Z',
+    source: 'user',
+  }),
+  removeMemories: vi.fn().mockReturnValue(2),
+  searchMemories: vi.fn().mockReturnValue([
+    { content: 'Uses pnpm', category: 'project', timestamp: '2024-01-15T11:00:00.000Z', source: 'user' },
+  ]),
+  clearMemories: vi.fn().mockReturnValue(3),
+  getMemoryPaths: vi.fn().mockReturnValue({
+    profile: '/home/user/.codi/profile.yaml',
+    memories: '/home/user/.codi/memories.md',
+    sessionNotes: '/home/user/.codi/session-notes.md',
+  }),
+  consolidateSessionNotes: vi.fn().mockReturnValue(5),
+}));
+
+// Mock the commands/index module
+vi.mock('../src/commands/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/commands/index.js')>('../src/commands/index.js');
+  return {
+    ...actual,
+    registerCommand: vi.fn(),
+  };
+});
+
+import {
+  loadProfile,
+  updateProfile,
+  loadMemories,
+  addMemory,
+  removeMemories,
+  searchMemories,
+  clearMemories,
+  consolidateSessionNotes,
+} from '../src/memory.js';
+import { registerCommand } from '../src/commands/index.js';
+
+const mockLoadProfile = vi.mocked(loadProfile);
+const mockUpdateProfile = vi.mocked(updateProfile);
+const mockLoadMemories = vi.mocked(loadMemories);
+const mockAddMemory = vi.mocked(addMemory);
+const mockRemoveMemories = vi.mocked(removeMemories);
+const mockSearchMemories = vi.mocked(searchMemories);
+const mockClearMemories = vi.mocked(clearMemories);
+const mockConsolidateSessionNotes = vi.mocked(consolidateSessionNotes);
+
+const createContext = (): CommandContext => ({
+  workingDirectory: '/test/project',
+});
+
+describe('Memory Commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rememberCommand', () => {
+    it('has correct name and aliases', () => {
+      expect(rememberCommand.name).toBe('remember');
+      expect(rememberCommand.aliases).toContain('mem');
+      expect(rememberCommand.aliases).toContain('note');
+    });
+
+    it('has taskType set to fast', () => {
+      expect(rememberCommand.taskType).toBe('fast');
+    });
+
+    it('returns error when no input provided', async () => {
+      const result = await rememberCommand.execute('', createContext());
+      expect(result).toContain('__MEMORY_ERROR__');
+      expect(result).toContain('Usage');
+    });
+
+    it('adds memory without category', async () => {
+      const result = await rememberCommand.execute('Prefers TypeScript', createContext());
+
+      expect(mockAddMemory).toHaveBeenCalledWith('Prefers TypeScript', undefined, 'user');
+      expect(result).toContain('__MEMORY_ADDED__');
+      expect(result).toContain('New memory content');
+    });
+
+    it('adds memory with category prefix', async () => {
+      mockAddMemory.mockReturnValueOnce({
+        content: 'Uses pnpm',
+        category: 'project',
+        timestamp: '2024-01-15T13:00:00.000Z',
+        source: 'user',
+      });
+
+      const result = await rememberCommand.execute('project: Uses pnpm', createContext());
+
+      expect(mockAddMemory).toHaveBeenCalledWith('Uses pnpm', 'project', 'user');
+      expect(result).toContain('__MEMORY_ADDED__');
+      expect(result).toContain('project');
+    });
+  });
+
+  describe('forgetCommand', () => {
+    it('has correct name and aliases', () => {
+      expect(forgetCommand.name).toBe('forget');
+      expect(forgetCommand.aliases).toContain('unmem');
+    });
+
+    it('returns error when no pattern provided', async () => {
+      const result = await forgetCommand.execute('', createContext());
+      expect(result).toContain('__MEMORY_ERROR__');
+      expect(result).toContain('Usage');
+    });
+
+    it('clears all memories when pattern is "all"', async () => {
+      const result = await forgetCommand.execute('all', createContext());
+
+      expect(mockClearMemories).toHaveBeenCalled();
+      expect(result).toContain('__MEMORY_CLEARED__');
+      expect(result).toContain('3');
+    });
+
+    it('removes memories matching pattern', async () => {
+      const result = await forgetCommand.execute('TypeScript', createContext());
+
+      expect(mockRemoveMemories).toHaveBeenCalledWith('TypeScript');
+      expect(result).toContain('__MEMORY_REMOVED__');
+      expect(result).toContain('2');
+    });
+
+    it('handles no matches found', async () => {
+      mockRemoveMemories.mockReturnValueOnce(0);
+      const result = await forgetCommand.execute('NonexistentPattern', createContext());
+
+      expect(result).toContain('__MEMORY_NOTFOUND__');
+      expect(result).toContain('NonexistentPattern');
+    });
+  });
+
+  describe('memoriesCommand', () => {
+    it('has correct name and aliases', () => {
+      expect(memoriesCommand.name).toBe('memories');
+      expect(memoriesCommand.aliases).toContain('mems');
+    });
+
+    it('lists all memories when no query provided', async () => {
+      const result = await memoriesCommand.execute('', createContext());
+
+      expect(mockLoadMemories).toHaveBeenCalled();
+      expect(result).toContain('__MEMORIES_LIST__');
+
+      const parts = result!.split('|');
+      const memories = JSON.parse(parts[1]);
+      expect(memories).toHaveLength(3);
+    });
+
+    it('searches memories when query provided', async () => {
+      const result = await memoriesCommand.execute('pnpm', createContext());
+
+      expect(mockSearchMemories).toHaveBeenCalledWith('pnpm');
+      expect(result).toContain('__MEMORIES_LIST__');
+
+      const parts = result!.split('|');
+      const memories = JSON.parse(parts[1]);
+      expect(memories).toHaveLength(1);
+      expect(memories[0].content).toContain('pnpm');
+    });
+
+    it('consolidates session notes', async () => {
+      const result = await memoriesCommand.execute('consolidate', createContext());
+
+      expect(mockConsolidateSessionNotes).toHaveBeenCalled();
+      expect(result).toContain('__MEMORY_CONSOLIDATED__');
+      expect(result).toContain('5');
+    });
+
+    it('handles zero consolidations', async () => {
+      mockConsolidateSessionNotes.mockReturnValueOnce(0);
+      const result = await memoriesCommand.execute('consolidate', createContext());
+
+      expect(result).toContain('__MEMORY_CONSOLIDATED__');
+      expect(result).toContain('0');
+    });
+  });
+
+  describe('profileCommand', () => {
+    it('has correct name and aliases', () => {
+      expect(profileCommand.name).toBe('profile');
+      expect(profileCommand.aliases).toContain('me');
+    });
+
+    it('shows profile when no args provided', async () => {
+      const result = await profileCommand.execute('', createContext());
+
+      expect(mockLoadProfile).toHaveBeenCalled();
+      expect(result).toContain('__PROFILE_SHOW__');
+
+      const parts = result!.split('|');
+      const profile = JSON.parse(parts[1]);
+      expect(profile.name).toBe('TestUser');
+      expect(profile.preferences.language).toBe('TypeScript');
+    });
+
+    it('updates profile with set command', async () => {
+      const result = await profileCommand.execute('set name NewUser', createContext());
+
+      expect(mockUpdateProfile).toHaveBeenCalledWith('name', 'NewUser');
+      expect(result).toContain('__PROFILE_UPDATED__');
+      expect(result).toContain('name');
+      expect(result).toContain('NewUser');
+    });
+
+    it('handles multi-word values', async () => {
+      const result = await profileCommand.execute('set expertise React and TypeScript', createContext());
+
+      expect(mockUpdateProfile).toHaveBeenCalledWith('expertise', 'React and TypeScript');
+    });
+
+    it('handles nested keys like preferences.language', async () => {
+      const result = await profileCommand.execute('set preferences.language Python', createContext());
+
+      expect(mockUpdateProfile).toHaveBeenCalledWith('preferences.language', 'Python');
+    });
+  });
+
+  describe('registerMemoryCommands', () => {
+    it('registers all memory commands', () => {
+      registerMemoryCommands();
+
+      expect(registerCommand).toHaveBeenCalledWith(rememberCommand);
+      expect(registerCommand).toHaveBeenCalledWith(forgetCommand);
+      expect(registerCommand).toHaveBeenCalledWith(memoriesCommand);
+      expect(registerCommand).toHaveBeenCalledWith(profileCommand);
+    });
+  });
+});

--- a/tests/orchestrate-commands.test.ts
+++ b/tests/orchestrate-commands.test.ts
@@ -1,0 +1,287 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  delegateCommand,
+  workersCommand,
+  worktreesCommand,
+  setOrchestrator,
+  getOrchestratorInstance,
+} from '../src/commands/orchestrate-commands.js';
+import type { CommandContext } from '../src/commands/index.js';
+
+// Mock chalk to avoid color codes in tests
+vi.mock('chalk', () => ({
+  default: {
+    yellow: (s: string) => s,
+    dim: (s: string) => s,
+    red: (s: string) => s,
+    green: (s: string) => s,
+    cyan: (s: string) => s,
+    blue: (s: string) => s,
+    magenta: (s: string) => s,
+    gray: (s: string) => s,
+    white: (s: string) => s,
+    bold: (s: string) => s,
+  },
+}));
+
+// Create mock orchestrator
+function createMockOrchestrator() {
+  return {
+    spawnWorker: vi.fn().mockResolvedValue('worker_123'),
+    getWorkers: vi.fn().mockReturnValue([
+      {
+        config: { id: 'worker_1', branch: 'feat/auth', task: 'implement auth' },
+        status: 'thinking',
+        currentTool: null,
+      },
+      {
+        config: { id: 'worker_2', branch: 'feat/api', task: 'add API' },
+        status: 'tool_call',
+        currentTool: 'write_file',
+      },
+    ]),
+    getActiveWorkers: vi.fn().mockReturnValue([]),
+    cancelWorker: vi.fn().mockResolvedValue(undefined),
+    waitAll: vi.fn().mockResolvedValue([]),
+    stop: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const createContext = (): CommandContext => ({
+  workingDirectory: '/test/project',
+});
+
+describe('Orchestrate Commands', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Reset module state
+    setOrchestrator(null);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  describe('delegateCommand', () => {
+    it('has correct name and aliases', () => {
+      expect(delegateCommand.name).toBe('delegate');
+      expect(delegateCommand.aliases).toContain('spawn');
+      expect(delegateCommand.aliases).toContain('worker');
+    });
+
+    it('shows usage when no args provided', async () => {
+      const result = await delegateCommand.execute('', createContext());
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalled();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('Usage:');
+    });
+
+    it('shows error when args are invalid', async () => {
+      const result = await delegateCommand.execute('only-branch', createContext());
+
+      expect(result).toBeNull();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('Invalid arguments');
+    });
+
+    it('shows error when orchestrator is not initialized', async () => {
+      const result = await delegateCommand.execute('feat/test "implement test"', createContext());
+
+      expect(result).toBeNull();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('Orchestrator not initialized');
+    });
+
+    it('spawns worker with valid args', async () => {
+      const mockOrch = createMockOrchestrator();
+      setOrchestrator(mockOrch as any);
+
+      const result = await delegateCommand.execute('feat/auth "implement authentication"', createContext());
+
+      expect(result).toBeNull();
+      expect(mockOrch.spawnWorker).toHaveBeenCalled();
+      const call = mockOrch.spawnWorker.mock.calls[0][0];
+      expect(call.branch).toBe('feat/auth');
+      expect(call.task).toBe('implement authentication');
+    });
+
+    it('parses --model flag', async () => {
+      const mockOrch = createMockOrchestrator();
+      setOrchestrator(mockOrch as any);
+
+      await delegateCommand.execute('feat/test "task" --model claude-3', createContext());
+
+      const call = mockOrch.spawnWorker.mock.calls[0][0];
+      expect(call.model).toBe('claude-3');
+    });
+
+    it('parses --provider flag', async () => {
+      const mockOrch = createMockOrchestrator();
+      setOrchestrator(mockOrch as any);
+
+      await delegateCommand.execute('feat/test "task" --provider anthropic', createContext());
+
+      const call = mockOrch.spawnWorker.mock.calls[0][0];
+      expect(call.provider).toBe('anthropic');
+    });
+
+    it('handles spawn error', async () => {
+      const mockOrch = createMockOrchestrator();
+      mockOrch.spawnWorker.mockRejectedValue(new Error('Branch already exists'));
+      setOrchestrator(mockOrch as any);
+
+      const result = await delegateCommand.execute('feat/test "task"', createContext());
+
+      expect(result).toBeNull();
+      const errorOutput = vi.mocked(console.error).mock.calls.flat().join('\n');
+      expect(errorOutput).toContain('Failed to spawn worker');
+    });
+  });
+
+  describe('workersCommand', () => {
+    it('has correct name', () => {
+      expect(workersCommand.name).toBe('workers');
+    });
+
+    it('shows "no workers active" when orchestrator is null', async () => {
+      const result = await workersCommand.execute('', createContext());
+
+      expect(result).toBeNull();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('No workers active');
+    });
+
+    it('shows no active workers message when none active', async () => {
+      const mockOrch = createMockOrchestrator();
+      mockOrch.getWorkers.mockReturnValue([]);
+      setOrchestrator(mockOrch as any);
+
+      const result = await workersCommand.execute('', createContext());
+
+      expect(result).toBeNull();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('No active workers');
+    });
+
+    it('lists active workers', async () => {
+      const mockOrch = createMockOrchestrator();
+      setOrchestrator(mockOrch as any);
+
+      const result = await workersCommand.execute('', createContext());
+
+      expect(result).toBeNull();
+      expect(mockOrch.getWorkers).toHaveBeenCalled();
+    });
+
+    it('cancels specific worker', async () => {
+      const mockOrch = createMockOrchestrator();
+      setOrchestrator(mockOrch as any);
+
+      const result = await workersCommand.execute('cancel worker_1', createContext());
+
+      expect(result).toBeNull();
+      expect(mockOrch.cancelWorker).toHaveBeenCalledWith('worker_1');
+    });
+
+    it('cancels worker by branch name', async () => {
+      const mockOrch = createMockOrchestrator();
+      setOrchestrator(mockOrch as any);
+
+      const result = await workersCommand.execute('cancel feat/auth', createContext());
+
+      expect(result).toBeNull();
+      expect(mockOrch.cancelWorker).toHaveBeenCalledWith('worker_1');
+    });
+
+    it('shows error when no worker ID provided for cancel', async () => {
+      const mockOrch = createMockOrchestrator();
+      setOrchestrator(mockOrch as any);
+
+      const result = await workersCommand.execute('cancel', createContext());
+
+      expect(result).toBeNull();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('Usage:');
+    });
+
+    it('shows error when worker not found', async () => {
+      const mockOrch = createMockOrchestrator();
+      mockOrch.getWorkers.mockReturnValue([]);
+      setOrchestrator(mockOrch as any);
+
+      const result = await workersCommand.execute('cancel unknown', createContext());
+
+      expect(result).toBeNull();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('Worker not found');
+    });
+
+    it('handles wait command with no active workers', async () => {
+      const mockOrch = createMockOrchestrator();
+      mockOrch.getActiveWorkers.mockReturnValue([]);
+      setOrchestrator(mockOrch as any);
+
+      const result = await workersCommand.execute('wait', createContext());
+
+      expect(result).toBeNull();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('No active workers to wait for');
+    });
+
+    it('handles cleanup command', async () => {
+      const mockOrch = createMockOrchestrator();
+      setOrchestrator(mockOrch as any);
+
+      const result = await workersCommand.execute('cleanup', createContext());
+
+      expect(result).toBeNull();
+      expect(mockOrch.stop).toHaveBeenCalled();
+    });
+
+    it('shows error for unknown action', async () => {
+      const mockOrch = createMockOrchestrator();
+      setOrchestrator(mockOrch as any);
+
+      const result = await workersCommand.execute('unknown', createContext());
+
+      expect(result).toBeNull();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('Unknown action');
+    });
+  });
+
+  describe('worktreesCommand', () => {
+    it('has correct name', () => {
+      expect(worktreesCommand.name).toBe('worktrees');
+    });
+
+    it('returns a prompt string for the AI', async () => {
+      const result = await worktreesCommand.execute('', createContext());
+
+      // worktreesCommand returns a prompt for the AI to list worktrees
+      expect(result).toContain('git worktree');
+    });
+  });
+
+  describe('getOrchestratorInstance', () => {
+    it('returns null when not set', () => {
+      setOrchestrator(null);
+      expect(getOrchestratorInstance()).toBeNull();
+    });
+
+    it('returns orchestrator when set', () => {
+      const mockOrch = createMockOrchestrator();
+      setOrchestrator(mockOrch as any);
+      expect(getOrchestratorInstance()).toBe(mockOrch);
+    });
+  });
+});

--- a/tests/rag-commands.test.ts
+++ b/tests/rag-commands.test.ts
@@ -1,0 +1,229 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  indexCommand,
+  ragCommand,
+  setRAGIndexer,
+  setRAGConfig,
+  registerRAGCommands,
+} from '../src/commands/rag-commands.js';
+import type { CommandContext } from '../src/commands/index.js';
+
+// Mock the commands/index module
+vi.mock('../src/commands/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/commands/index.js')>('../src/commands/index.js');
+  return {
+    ...actual,
+    registerCommand: vi.fn(),
+  };
+});
+
+import { registerCommand } from '../src/commands/index.js';
+
+// Create mock indexer
+function createMockIndexer() {
+  return {
+    getStats: vi.fn().mockResolvedValue({
+      embeddingProvider: 'OpenAI',
+      embeddingModel: 'text-embedding-3-small',
+      totalFiles: 100,
+      totalChunks: 500,
+      indexSizeBytes: 1024 * 1024, // 1 MB
+      lastIndexed: new Date(),
+      isIndexing: false,
+      queuedFiles: 0,
+    }),
+    isIndexingInProgress: vi.fn().mockReturnValue(false),
+    clearIndex: vi.fn().mockResolvedValue(undefined),
+    indexAll: vi.fn().mockResolvedValue({ totalFiles: 100, totalChunks: 500 }),
+    getVectorStore: vi.fn().mockReturnValue({
+      getIndexedFiles: vi.fn().mockResolvedValue(['src/index.ts', 'src/agent.ts']),
+    }),
+  };
+}
+
+function createMockRAGConfig() {
+  return {
+    enabled: true,
+    embeddingProvider: 'openai' as const,
+    openaiModel: 'text-embedding-3-small',
+    ollamaModel: 'nomic-embed-text',
+    topK: 5,
+    minScore: 0.7,
+    autoIndex: true,
+    watchFiles: false,
+    includePatterns: ['**/*.ts', '**/*.js'],
+    excludePatterns: ['node_modules/**'],
+  };
+}
+
+const createContext = (): CommandContext => ({
+  workingDirectory: '/test/project',
+});
+
+describe('RAG Commands', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Reset module state
+    setRAGIndexer(null as any);
+    setRAGConfig(null as any);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  describe('indexCommand', () => {
+    it('has correct name and aliases', () => {
+      expect(indexCommand.name).toBe('index');
+      expect(indexCommand.aliases).toContain('reindex');
+    });
+
+    it('shows help when indexer is not available', async () => {
+      const result = await indexCommand.execute('', createContext());
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalled();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('RAG system is not available');
+    });
+
+    it('shows status with --status flag when indexer is available', async () => {
+      const mockIndexer = createMockIndexer();
+      setRAGIndexer(mockIndexer as any);
+
+      const result = await indexCommand.execute('--status', createContext());
+
+      expect(result).toBeNull();
+      expect(mockIndexer.getStats).toHaveBeenCalled();
+    });
+
+    it('does not start indexing if already in progress', async () => {
+      const mockIndexer = createMockIndexer();
+      mockIndexer.isIndexingInProgress.mockReturnValue(true);
+      setRAGIndexer(mockIndexer as any);
+
+      const result = await indexCommand.execute('', createContext());
+
+      expect(result).toBeNull();
+      expect(mockIndexer.indexAll).not.toHaveBeenCalled();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('already in progress');
+    });
+
+    it('clears index with --clear flag', async () => {
+      const mockIndexer = createMockIndexer();
+      setRAGIndexer(mockIndexer as any);
+
+      const result = await indexCommand.execute('--clear', createContext());
+
+      expect(result).toBeNull();
+      expect(mockIndexer.clearIndex).toHaveBeenCalled();
+      expect(mockIndexer.indexAll).toHaveBeenCalled();
+    });
+
+    it('starts incremental indexing without --clear', async () => {
+      const mockIndexer = createMockIndexer();
+      setRAGIndexer(mockIndexer as any);
+
+      const result = await indexCommand.execute('', createContext());
+
+      expect(result).toBeNull();
+      expect(mockIndexer.clearIndex).not.toHaveBeenCalled();
+      expect(mockIndexer.indexAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('ragCommand', () => {
+    it('has correct name and aliases', () => {
+      expect(ragCommand.name).toBe('rag');
+      expect(ragCommand.aliases).toContain('rag-status');
+    });
+
+    it('shows help with "help" action', async () => {
+      const result = await ragCommand.execute('help', createContext());
+
+      expect(result).toBeNull();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('Retrieval-Augmented Generation');
+      expect(output).toContain('Commands:');
+    });
+
+    it('shows not enabled message when indexer is not available', async () => {
+      const result = await ragCommand.execute('', createContext());
+
+      expect(result).toBeNull();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('RAG system is not enabled');
+    });
+
+    it('shows config with "config" action', async () => {
+      const mockIndexer = createMockIndexer();
+      const mockConfig = createMockRAGConfig();
+      setRAGIndexer(mockIndexer as any);
+      setRAGConfig(mockConfig);
+
+      const result = await ragCommand.execute('config', createContext());
+
+      expect(result).toBeNull();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('RAG Configuration');
+      expect(output).toContain('text-embedding-3-small');
+    });
+
+    it('shows indexed files with "files" action', async () => {
+      const mockIndexer = createMockIndexer();
+      const mockConfig = createMockRAGConfig();
+      setRAGIndexer(mockIndexer as any);
+      setRAGConfig(mockConfig);
+
+      const result = await ragCommand.execute('files', createContext());
+
+      expect(result).toBeNull();
+      expect(mockIndexer.getVectorStore).toHaveBeenCalled();
+    });
+
+    it('shows status by default', async () => {
+      const mockIndexer = createMockIndexer();
+      const mockConfig = createMockRAGConfig();
+      setRAGIndexer(mockIndexer as any);
+      setRAGConfig(mockConfig);
+
+      const result = await ragCommand.execute('', createContext());
+
+      expect(result).toBeNull();
+      expect(mockIndexer.getStats).toHaveBeenCalled();
+    });
+
+    it('handles error when listing files', async () => {
+      const mockIndexer = createMockIndexer();
+      mockIndexer.getVectorStore.mockReturnValue({
+        getIndexedFiles: vi.fn().mockRejectedValue(new Error('Index not found')),
+      });
+      const mockConfig = createMockRAGConfig();
+      setRAGIndexer(mockIndexer as any);
+      setRAGConfig(mockConfig);
+
+      const result = await ragCommand.execute('files', createContext());
+
+      expect(result).toBeNull();
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('Failed to list files');
+    });
+  });
+
+  describe('registerRAGCommands', () => {
+    it('registers both RAG commands', () => {
+      registerRAGCommands();
+
+      expect(registerCommand).toHaveBeenCalledWith(indexCommand);
+      expect(registerCommand).toHaveBeenCalledWith(ragCommand);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for 4 command modules (Tier 3, item 3.3)
- compact-commands.test.ts: 16 tests covering status, summarize, and compress subcommands
- memory-commands.test.ts: 21 tests covering remember, forget, memories, and profile commands
- rag-commands.test.ts: 14 tests covering index and rag commands with status/config/files
- orchestrate-commands.test.ts: 23 tests covering delegate, workers, and worktrees commands
- Total: 74 new tests, all passing

## Test plan
- [x] All 74 new command tests pass
- [x] Full test suite passes (1781 tests)
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)