### PR TITLE
feat: support global model maps (~/.codi/models.yaml)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1598,9 +1598,15 @@ function handleModelMapOutput(output: string): void {
   }
 
   if (firstLine.startsWith('__MODELMAP_INIT__|')) {
-    const path = firstLine.slice('__MODELMAP_INIT__|'.length);
-    console.log(chalk.green(`\nCreated model map: ${path}`));
-    console.log(chalk.dim('Edit this file to configure multi-model orchestration.'));
+    const parts = firstLine.slice('__MODELMAP_INIT__|'.length).split('|');
+    const filePath = parts[0];
+    const scope = parts[1] || 'project';
+    console.log(chalk.green(`\nCreated ${scope} model map: ${filePath}`));
+    if (scope === 'global') {
+      console.log(chalk.dim('Global models can be used in any project with /switch <name>'));
+    } else {
+      console.log(chalk.dim('Edit this file to configure multi-model orchestration.'));
+    }
     return;
   }
 
@@ -1621,6 +1627,12 @@ function handleModelMapOutput(output: string): void {
       const type = parts[0];
 
       switch (type) {
+        case 'globalPath':
+          console.log(chalk.dim(`Global: ${parts[1]}`));
+          break;
+        case 'projectPath':
+          console.log(chalk.dim(`Project: ${parts[1]}`));
+          break;
         case 'path':
           console.log(chalk.dim(`File: ${parts[1]}`));
           break;

--- a/src/model-map/index.ts
+++ b/src/model-map/index.ts
@@ -16,12 +16,15 @@ import { shutdownAllRateLimiters } from '../providers/rate-limiter.js';
 // Loader
 export {
   loadModelMap,
+  loadProjectModelMap,
   validateModelMap,
   watchModelMap,
   getExampleModelMap,
   initModelMap as initModelMapFile,
+  getGlobalConfigDir,
   ModelMapValidationError,
   type ValidationResult,
+  type ModelMapLoadResult,
 } from './loader.js';
 
 // Registry
@@ -149,7 +152,8 @@ import type { PipelineExecutor } from './executor.js';
  */
 export interface ModelMap {
   config: ModelMapConfig;
-  configPath: string | null;
+  configPath: string | null;        // Project config path (if exists)
+  globalConfigPath: string | null;  // Global config path (if exists)
   registry: ModelRegistry;
   router: TaskRouter;
   executor: PipelineExecutor;
@@ -160,13 +164,16 @@ export interface ModelMap {
 }
 
 /**
- * Initialize a complete model map from the current directory.
+ * Initialize a complete model map from global and/or project config.
  *
- * @param cwd Working directory to load config from
+ * Global config (~/.codi/models.yaml) is loaded first, then project config
+ * (codi-models.yaml) overrides global settings.
+ *
+ * @param cwd Working directory to load project config from
  * @returns ModelMap instance or null if no config found
  */
 export function initModelMap(cwd: string = process.cwd()): ModelMap | null {
-  const { config, configPath, error } = loadModelMap(cwd);
+  const { config, configPath, globalConfigPath, error } = loadModelMap(cwd);
 
   if (!config) {
     if (error) {
@@ -216,6 +223,7 @@ export function initModelMap(cwd: string = process.cwd()): ModelMap | null {
   return {
     config,
     configPath,
+    globalConfigPath,
     registry,
     router,
     executor,

--- a/src/model-map/loader.ts
+++ b/src/model-map/loader.ts
@@ -9,6 +9,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { homedir } from 'os';
 import yaml from 'js-yaml';
 import type {
   ModelMapConfig,
@@ -25,6 +26,15 @@ const MODEL_MAP_FILE = 'codi-models.yaml';
 
 /** Alternative config file name */
 const MODEL_MAP_FILE_ALT = 'codi-models.yml';
+
+/** Global config directory */
+const GLOBAL_CONFIG_DIR = path.join(homedir(), '.codi');
+
+/** Global config file name */
+const GLOBAL_MODEL_MAP_FILE = 'models.yaml';
+
+/** Alternative global config file name */
+const GLOBAL_MODEL_MAP_FILE_ALT = 'models.yml';
 
 /**
  * Validation error for model map configuration.
@@ -49,19 +59,29 @@ export interface ValidationResult {
 }
 
 /**
- * Load model map configuration from a directory.
- * Searches for codi-models.yaml or codi-models.yml
+ * Extended result with global config path information.
  */
-export function loadModelMap(cwd: string = process.cwd()): {
+export interface ModelMapLoadResult {
   config: ModelMapConfig | null;
-  configPath: string | null;
+  configPath: string | null;       // Project config path (if exists)
+  globalConfigPath: string | null; // Global config path (if exists)
   error?: string;
-} {
+}
+
+/**
+ * Load a single model map configuration from a directory.
+ * Internal helper that checks for yaml/yml variants.
+ */
+function loadSingleModelMap(
+  dir: string,
+  primaryFile: string,
+  altFile: string
+): { config: ModelMapConfig | null; configPath: string | null; error?: string } {
   // Try primary name first
-  let configPath = path.join(cwd, MODEL_MAP_FILE);
+  let configPath = path.join(dir, primaryFile);
   if (!fs.existsSync(configPath)) {
     // Try alternative name
-    configPath = path.join(cwd, MODEL_MAP_FILE_ALT);
+    configPath = path.join(dir, altFile);
     if (!fs.existsSync(configPath)) {
       return { config: null, configPath: null };
     }
@@ -85,6 +105,113 @@ export function loadModelMap(cwd: string = process.cwd()): {
     const message = error instanceof Error ? error.message : String(error);
     return { config: null, configPath, error: `Failed to parse ${configPath}: ${message}` };
   }
+}
+
+/**
+ * Deep merge two objects (right overrides left).
+ * Used for merging model-roles which are nested objects.
+ */
+function deepMergeObjects<T extends Record<string, unknown>>(
+  left: T | undefined,
+  right: T | undefined
+): T {
+  if (!left) return (right || {}) as T;
+  if (!right) return left;
+
+  const result = { ...left } as T;
+  for (const key of Object.keys(right)) {
+    const leftVal = left[key];
+    const rightVal = right[key];
+
+    if (
+      typeof leftVal === 'object' &&
+      leftVal !== null &&
+      !Array.isArray(leftVal) &&
+      typeof rightVal === 'object' &&
+      rightVal !== null &&
+      !Array.isArray(rightVal)
+    ) {
+      // Deep merge nested objects
+      (result as Record<string, unknown>)[key] = deepMergeObjects(
+        leftVal as Record<string, unknown>,
+        rightVal as Record<string, unknown>
+      );
+    } else {
+      // Override
+      (result as Record<string, unknown>)[key] = rightVal;
+    }
+  }
+  return result;
+}
+
+/**
+ * Merge two model map configs (project overrides global).
+ */
+function mergeModelMapConfigs(
+  globalConfig: ModelMapConfig | null,
+  projectConfig: ModelMapConfig | null
+): ModelMapConfig | null {
+  if (!globalConfig && !projectConfig) return null;
+  if (!globalConfig) return projectConfig;
+  if (!projectConfig) return globalConfig;
+
+  return {
+    version: projectConfig.version || globalConfig.version,
+    models: { ...globalConfig.models, ...projectConfig.models },
+    'model-roles': deepMergeObjects(globalConfig['model-roles'], projectConfig['model-roles']),
+    tasks: { ...globalConfig.tasks, ...projectConfig.tasks },
+    commands: { ...globalConfig.commands, ...projectConfig.commands },
+    fallbacks: { ...globalConfig.fallbacks, ...projectConfig.fallbacks },
+    pipelines: { ...globalConfig.pipelines, ...projectConfig.pipelines },
+  };
+}
+
+/**
+ * Load model map configuration from global and/or project directory.
+ * Global config (~/.codi/models.yaml) is loaded first, then project config
+ * (codi-models.yaml) overrides global settings.
+ *
+ * @param cwd Working directory for project config (default: process.cwd())
+ * @returns Merged config with paths for both global and project configs
+ */
+export function loadModelMap(cwd: string = process.cwd()): ModelMapLoadResult {
+  // Load global config (if exists)
+  const globalResult = loadSingleModelMap(
+    GLOBAL_CONFIG_DIR,
+    GLOBAL_MODEL_MAP_FILE,
+    GLOBAL_MODEL_MAP_FILE_ALT
+  );
+
+  // Load project config (if exists)
+  const projectResult = loadSingleModelMap(cwd, MODEL_MAP_FILE, MODEL_MAP_FILE_ALT);
+
+  // Collect errors
+  const errors: string[] = [];
+  if (globalResult.error) errors.push(globalResult.error);
+  if (projectResult.error) errors.push(projectResult.error);
+
+  // Merge configs (project overrides global)
+  const merged = mergeModelMapConfigs(globalResult.config, projectResult.config);
+
+  return {
+    config: merged,
+    configPath: projectResult.configPath,
+    globalConfigPath: globalResult.configPath,
+    error: errors.length > 0 ? errors.join('; ') : undefined,
+  };
+}
+
+/**
+ * Load model map from project directory only (no global).
+ * Backwards-compatible version of loadModelMap.
+ * @deprecated Use loadModelMap() which supports global configs
+ */
+export function loadProjectModelMap(cwd: string = process.cwd()): {
+  config: ModelMapConfig | null;
+  configPath: string | null;
+  error?: string;
+} {
+  return loadSingleModelMap(cwd, MODEL_MAP_FILE, MODEL_MAP_FILE_ALT);
 }
 
 /**
@@ -524,41 +651,75 @@ export function getExampleModelMap(): string {
 }
 
 /**
- * Initialize a new codi-models.yaml file.
+ * Initialize a new model map file.
+ *
+ * @param cwd Directory to create the file in (default: process.cwd())
+ * @param global If true, creates in ~/.codi/ instead of cwd
  */
-export function initModelMap(cwd: string = process.cwd()): {
+export function initModelMap(
+  cwd: string = process.cwd(),
+  global: boolean = false
+): {
   success: boolean;
   path: string;
+  isGlobal: boolean;
   error?: string;
 } {
-  const configPath = path.join(cwd, MODEL_MAP_FILE);
+  const targetDir = global ? GLOBAL_CONFIG_DIR : cwd;
+  const fileName = global ? GLOBAL_MODEL_MAP_FILE : MODEL_MAP_FILE;
+  const altFileName = global ? GLOBAL_MODEL_MAP_FILE_ALT : MODEL_MAP_FILE_ALT;
+  const configPath = path.join(targetDir, fileName);
+
+  // Ensure directory exists for global config
+  if (global && !fs.existsSync(targetDir)) {
+    try {
+      fs.mkdirSync(targetDir, { recursive: true });
+    } catch (error) {
+      return {
+        success: false,
+        path: configPath,
+        isGlobal: global,
+        error: `Failed to create directory: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
 
   if (fs.existsSync(configPath)) {
     return {
       success: false,
       path: configPath,
+      isGlobal: global,
       error: 'Model map file already exists',
     };
   }
 
   // Also check alternate name
-  const altPath = path.join(cwd, MODEL_MAP_FILE_ALT);
+  const altPath = path.join(targetDir, altFileName);
   if (fs.existsSync(altPath)) {
     return {
       success: false,
       path: altPath,
+      isGlobal: global,
       error: 'Model map file already exists',
     };
   }
 
   try {
     fs.writeFileSync(configPath, getExampleModelMap());
-    return { success: true, path: configPath };
+    return { success: true, path: configPath, isGlobal: global };
   } catch (error) {
     return {
       success: false,
       path: configPath,
+      isGlobal: global,
       error: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+/**
+ * Get the global config directory path.
+ */
+export function getGlobalConfigDir(): string {
+  return GLOBAL_CONFIG_DIR;
 }


### PR DESCRIPTION
## Summary
Add support for global model maps that can be reused across all projects.

### Features
- **Global config location**: `~/.codi/models.yaml` (or `models.yml`)
- **Merge behavior**: Project config overrides global
- **Deep merge**: model-roles section is deeply merged
- **Init flag**: `/modelmap init --global` creates global config
- **Show command**: Displays both config sources

### Usage
```bash
# Create global models once
/modelmap init --global

# Edit ~/.codi/models.yaml
models:
  coder:
    provider: ollama-cloud
    model: qwen3-coder:480b-cloud
  fast:
    provider: anthropic
    model: claude-3-5-haiku-latest

# Use anywhere!
/switch coder   # Works in any project
/switch fast    # Works in any project
```

### Merge Priority
- Global models are loaded first
- Project models with same name override global
- Same for tasks, pipelines, fallbacks, commands

## Test plan
- [x] Build passes
- [x] All 1781 tests pass
- [x] `/modelmap show` displays global and project paths
- [x] `/modelmap init --global` creates `~/.codi/models.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)