### PR TITLE
feat: add interactive model addition to model map

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1597,6 +1597,17 @@ function handleModelMapOutput(output: string): void {
     return;
   }
 
+  if (firstLine.startsWith('__MODELMAP_ADD__|')) {
+    const parts = firstLine.slice('__MODELMAP_ADD__|'.length).split('|');
+    const [name, provider, model, filePath, scope] = parts;
+    console.log(chalk.green(`\nAdded model "${name}" to ${scope} config`));
+    console.log(chalk.dim(`  Provider: ${provider}`));
+    console.log(chalk.dim(`  Model: ${model}`));
+    console.log(chalk.dim(`  File: ${filePath}`));
+    console.log(chalk.cyan(`\nUse with: /switch ${name}`));
+    return;
+  }
+
   if (firstLine.startsWith('__MODELMAP_INIT__|')) {
     const parts = firstLine.slice('__MODELMAP_INIT__|'.length).split('|');
     const filePath = parts[0];

--- a/src/model-map/index.ts
+++ b/src/model-map/index.ts
@@ -21,6 +21,7 @@ export {
   watchModelMap,
   getExampleModelMap,
   initModelMap as initModelMapFile,
+  addModelToMap,
   getGlobalConfigDir,
   ModelMapValidationError,
   type ValidationResult,


### PR DESCRIPTION
## Summary
Add `/modelmap add` command to add models interactively without editing YAML files.

### Usage
```bash
/modelmap add <name> <provider> <model> [description]
/modelmap add --global <name> <provider> <model> [description]
```

### Examples
```bash
# Add to project config
/modelmap add coder ollama-cloud qwen3-coder:480b-cloud

# Add to global config with description
/modelmap add --global fast anthropic claude-3-5-haiku-latest "Quick tasks"

# Then use anywhere
/switch coder
/switch fast
```

### Features
- Creates config file if it doesn't exist (minimal config with just models section)
- Validates provider name (anthropic, openai, ollama, ollama-cloud, runpod)
- Prevents duplicate model names
- Supports `--global` flag for `~/.codi/models.yaml`
- Shows usage hint after adding

## Test plan
- [x] Build passes
- [x] All 1781 tests pass
- [x] `/modelmap add` validates provider
- [x] `/modelmap add --global` creates ~/.codi/models.yaml if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)