### PR TITLE
fix: correct clearMessageTokenCache documentation

### DIFF
--- a/src/utils/token-counter.ts
+++ b/src/utils/token-counter.ts
@@ -195,10 +195,14 @@ export function invalidateMessageTokenCache(msg: Message): void {
 
 /**
  * Clear all cached token counts (for testing).
+ *
+ * NOTE: WeakMap doesn't have a clear() method and is designed for automatic
+ * garbage collection. For testing, individual messages should be invalidated
+ * using invalidateMessageTokenCache() instead.
  */
 export function clearMessageTokenCache(): void {
-  // WeakMap doesn't have a clear method, so we reassign
-  // This is only for testing - in production the WeakMap handles cleanup
+  // No-op: WeakMap manages its own lifecycle and cannot be cleared directly
+  // Use invalidateMessageTokenCache(msg) for individual message invalidation
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixed misleading documentation in  function. The docstring said "so we reassign" but the function body was empty -  has no  method and cannot be cleared directly.

## Changes

- Updated :
  - Removed misleading "so we reassign" comment
  - Added NOTE explaining WeakMap's automatic garbage collection behavior
  - Documented the proper way to clear individual entries ()

## Testing

- All 157 unit tests pass
- TypeScript compilation succeeds with no errors

---Wingman: Codi <codi@layne.pro>