### PR TITLE
docs: update ROADMAP.md with v0.16.0 status

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,38 +1,175 @@
 # Codi Roadmap
 
-This document tracks planned features and improvements for Codi.
-
-## Planned Features
-
-### Test Sandbox Compatibility
-
-Update tests that write to `~/.codi` or bind to `127.0.0.1` so they use local temporary
-directories and ephemeral ports by default, avoiding sandbox permission errors.
+**Current Version:** 0.16.0
+**Last Updated:** 2026-01-23
 
 ---
+
+## Overview
+
+Codi is a feature-rich AI coding assistant CLI. This document tracks completed work and remaining tasks for production readiness.
+
+---
+
+## Recently Completed (v0.15.0 - v0.16.0)
+
+### Tier 1: Critical Security & Stability
+
+| Item | Status | PR |
+|------|--------|-----|
+| Fix dependency vulnerabilities (diff, esbuild) | ✅ Complete | #86 |
+| Add path traversal protection to file tools | ✅ Complete | #87 |
+| Fix database cleanup on exit (SQLite) | ✅ Complete | #88 |
+| Implement memory bounds (message cap, LRU eviction) | ✅ Complete | #89 |
+
+### Tier 2: Testing & CI/CD
+
+| Item | Status | PR |
+|------|--------|-----|
+| Core module unit tests (agent, MCP, orchestration) | ✅ Complete | #90 |
+| CI enhancements (macOS runner) | ✅ Complete | #91 |
+| NPM publishing setup | ✅ Complete | #92 |
+| Environment documentation (.env.example) | ✅ Complete | #93 |
+
+### Tier 3: Polish
+
+| Item | Status | PR |
+|------|--------|-----|
+| Concurrency safety (tool execution semaphore) | ✅ Complete | #94 |
+| Rate limiter queue bounds | ✅ Complete | #94 |
+| Graceful shutdown handlers | ✅ Complete | #94 |
+| README improvements | ✅ Complete | #94 |
+
+### Tier 4: Performance & Security
+
+| Item | Status | PR |
+|------|--------|-----|
+| Token count caching | ✅ Complete | #95 |
+| Gzip compression for tool result cache | ✅ Complete | #95 |
+| Parallel Ollama embeddings | ✅ Complete | #95 |
+| SQLite VACUUM scheduling | ✅ Complete | #95 |
+| SECURITY.md with threat model | ✅ Complete | #96 |
+
+### New Features (v0.16.0)
+
+| Feature | Description | PR |
+|---------|-------------|-----|
+| Global Model Maps | `~/.codi/models.yaml` for cross-project model aliases | #99 |
+| Interactive Model Addition | `/modelmap add [--global] name provider model` | #100 |
+| Debug Bridge | `--debug-bridge` flag streams events to JSONL for live debugging | #101 |
+
+---
+
+## Current Status
+
+**Tests:** 1801 passing
+**Test Coverage:** ~65% overall
+
+| Module | Coverage |
+|--------|----------|
+| Tools | ~95% |
+| Providers | ~75% |
+| Commands | ~60% |
+| Orchestration | ~70% |
+
+---
+
+## Remaining Work
+
+### High Priority
+
+- [ ] **Windows CI runner** - Test native module compilation on Windows
+- [ ] **npm publish workflow** - Automated releases on tag push (`.github/workflows/release.yml`)
+- [ ] **Command unit tests** - memory-commands, orchestrate-commands, rag-commands, compact-commands
+
+### Medium Priority
+
+- [ ] **Enhanced bash security** - Use array-based `execFile()` instead of `exec()`
+- [ ] **Structured logging** - Implement log levels beyond current debug flags
+- [ ] **Health check endpoint** - For long-running processes
+
+### Nice to Have
+
+- [ ] **Debug Bridge Phase 2** - Command injection (pause, resume, inject_message)
+- [ ] **Optional telemetry** - Opt-in error tracking
+- [ ] **Plugin system re-enable** - Currently disabled pending investigation (#17)
+
+---
+
+## Planned Features
 
 ### Semantic Fallback for Tool Calls
 
 When a model attempts to call a tool that doesn't exist or uses incorrect parameter names, implement a semantic fallback system that:
 
-1. **Tool Name Matching**: If a requested tool doesn't exist, find the closest matching tool by name similarity (e.g., `print_tree` -> `list_directory`, `search` -> `grep`)
-
-2. **Parameter Mapping**: When a tool is called with unrecognized parameters, attempt to map them to the correct parameter names based on:
-   - Common aliases (e.g., `query` -> `pattern`, `max_results` -> `head_limit`)
-   - Semantic similarity (e.g., `search_term` -> `pattern`)
-   - Parameter descriptions
-
-3. **Graceful Degradation**: Instead of failing on invalid tool calls, provide helpful feedback to the model about what tools/parameters are available
-
-This would help bridge the gap between different model training data and Codi's actual tool definitions, improving compatibility with various LLMs.
+1. **Tool Name Matching**: Find closest matching tool by name similarity (e.g., `print_tree` -> `list_directory`)
+2. **Parameter Mapping**: Map unrecognized parameters to correct names based on aliases and semantic similarity
+3. **Graceful Degradation**: Provide helpful feedback instead of failing on invalid tool calls
 
 **Current Mitigations**:
-- Added parameter aliases to `grep` tool (`query` -> `pattern`, `max_results`/`max`/`limit` -> `head_limit`)
+- Added parameter aliases to `grep` tool (`query` -> `pattern`, `max_results` -> `head_limit`)
 - Added `print_tree` tool (commonly expected by models)
-- Consider a vector-embedding index for tool/parameter semantics (similar to `search_codebase`) to improve matches beyond string similarity.
+
+### Test Sandbox Compatibility
+
+Update tests that write to `~/.codi` or bind to `127.0.0.1` to use local temporary directories and ephemeral ports by default.
 
 ---
 
-## Completed Features
+## Feature Overview
 
-See [CLAUDE.md](./CLAUDE.md) for documentation on implemented features.
+### Core Features
+- Multi-provider support (Anthropic, OpenAI, Ollama, RunPod)
+- 27 tools for file operations, search, and code intelligence
+- 48 slash commands for workflows
+- Session persistence and restoration
+- Context compaction with summarization
+
+### Advanced Features
+- Multi-agent orchestration with git worktrees
+- Symbol index with SQLite backend (1146 symbols)
+- RAG system for semantic code search
+- Model map for multi-model pipelines
+- Debug bridge for live session debugging
+
+### Security Features
+- User approval system for tool execution
+- Dangerous pattern detection for bash commands
+- Path traversal protection
+- Audit logging (`--audit` flag)
+
+---
+
+## Release History
+
+| Version | Date | Highlights |
+|---------|------|------------|
+| 0.16.0 | 2026-01-23 | Debug bridge, global model maps, interactive model addition |
+| 0.15.0 | 2026-01-22 | Production readiness (Tiers 1-4 complete) |
+| 0.14.0 | 2026-01-20 | Symbol index, performance optimizations |
+| 0.13.0 | 2026-01-18 | Multi-agent orchestration |
+| 0.12.0 | 2026-01-15 | Model map pipelines |
+
+---
+
+## Architecture
+
+```
+src/
+├── index.ts          # CLI entry, REPL loop
+├── agent.ts          # Core agent loop
+├── debug-bridge.ts   # Live debugging event stream
+├── commands/         # 48 slash commands
+├── providers/        # AI model backends
+├── tools/            # 27 filesystem tools
+├── orchestrate/      # Multi-agent with IPC
+├── model-map/        # Multi-model orchestration
+├── symbol-index/     # Code intelligence
+└── rag/              # Semantic search
+```
+
+---
+
+## Contributing
+
+See [CLAUDE.md](./CLAUDE.md) for development guidelines and [SECURITY.md](./SECURITY.md) for security practices.


### PR DESCRIPTION
## Summary

Update ROADMAP.md to reflect completed work and current project status.

## Changes

- Document all completed Tier 1-4 items with PR references
- Add new v0.16.0 features (debug bridge, global model maps, interactive model addition)
- Update test coverage status (1801 tests, ~65% coverage)
- List remaining high/medium/nice-to-have work
- Add release history and architecture overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)