### PR TITLE
docs: update plan and roadmap for debug bridge Phase 2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,12 +57,14 @@ Codi is a feature-rich AI coding assistant CLI. This document tracks completed w
 | Global Model Maps | `~/.codi/models.yaml` for cross-project model aliases | #99 |
 | Interactive Model Addition | `/modelmap add [--global] name provider model` | #100 |
 | Debug Bridge | `--debug-bridge` flag streams events to JSONL for live debugging | #101 |
+| Debug Bridge Session Isolation | Unique directories per session, current symlink, session index | #109 |
+| Debug Bridge Command Injection | External control via commands.jsonl (pause, resume, step, inspect) | #110 |
 
 ---
 
 ## Current Status
 
-**Tests:** 1801 passing
+**Tests:** 1813 passing
 **Test Coverage:** ~65% overall
 
 | Module | Coverage |
@@ -90,7 +92,8 @@ Codi is a feature-rich AI coding assistant CLI. This document tracks completed w
 
 ### Nice to Have
 
-- [ ] **Debug Bridge Phase 2** - Command injection (pause, resume, inject_message)
+- [x] **Debug Bridge Phase 2** - Command injection (pause, resume, step, inspect) - PR #110
+- [ ] **Debug Bridge Phase 3** - Debug CLI (`codi-debug`) and breakpoints
 - [ ] **Optional telemetry** - Opt-in error tracking
 - [ ] **Plugin system re-enable** - Currently disabled pending investigation (#17)
 

--- a/docs/DEBUG-BRIDGE-PLAN.md
+++ b/docs/DEBUG-BRIDGE-PLAN.md
@@ -2,6 +2,8 @@
 
 **Goal:** Extend the debug bridge to support bidirectional communication, allowing external debuggers to control Codi sessions.
 
+**Status:** Phase 2 Complete (PR #110)
+
 ---
 
 ## Current State (Phase 1 - Complete in v0.16.0)
@@ -16,18 +18,9 @@ The debug bridge streams events to `~/.codi/debug/events.jsonl`:
 
 **Files:** `src/debug-bridge.ts`, hooks in `src/agent.ts` and `src/index.ts`
 
-### Known Issue: Global Files
-
-Currently all sessions write to the same files:
-- `~/.codi/debug/events.jsonl`
-- `~/.codi/debug/commands.jsonl`
-- `~/.codi/debug/session.json`
-
-This causes conflicts when running multiple Codi instances.
-
 ---
 
-## Phase 1.5: Session-Unique Files (Prerequisite Fix)
+## Phase 1.5: Session-Unique Files ✅ Complete (PR #109)
 
 ### Problem
 
@@ -139,7 +132,7 @@ shutdown(): void {
 
 ---
 
-## Phase 2: Command Injection
+## Phase 2: Command Injection ✅ Complete (PR #110)
 
 ### Overview
 


### PR DESCRIPTION
## Summary

Update documentation to reflect completed Debug Bridge Phase 2 work.

**Changes:**
- Mark Phase 1.5 (session isolation) as complete in DEBUG-BRIDGE-PLAN.md
- Mark Phase 2 (command injection) as complete in DEBUG-BRIDGE-PLAN.md  
- Update ROADMAP.md with completed Phase 2 features (#109, #110)
- Update test count from 1801 to 1813

## Test plan
- [x] Documentation only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)