### PR TITLE
fix: use relative symlink for debug bridge current session

### DIFF
--- a/src/debug-bridge.ts
+++ b/src/debug-bridge.ts
@@ -225,8 +225,9 @@ export class DebugBridge {
       if (existsSync(CURRENT_LINK)) {
         unlinkSync(CURRENT_LINK);
       }
-      // Create symlink to current session
-      symlinkSync(this.sessionDir, CURRENT_LINK);
+      // Create relative symlink to current session (sessions/<session-id>)
+      const relativeTarget = join('sessions', this.sessionId);
+      symlinkSync(relativeTarget, CURRENT_LINK);
     } catch {
       // Symlinks may fail on Windows or due to permissions, ignore
     }


### PR DESCRIPTION
## Summary

- Changes the `current` symlink from an absolute path to a relative path (`sessions/<session-id>`)
- Makes the symlink portable and consistent regardless of the debug directory's absolute location

**Before:** `current -> /Users/name/.codi/debug/sessions/<id>`
**After:** `current -> sessions/<id>`

## Test plan

- [x] All debug bridge tests pass (32 tests)
- [x] Verified symlink resolution works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)