### PR TITLE
test: add e2e tests for Debug Bridge Phase 4

### DIFF
--- a/tests/debug-bridge.e2e.test.ts
+++ b/tests/debug-bridge.e2e.test.ts
@@ -1,0 +1,664 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * E2E tests for Debug Bridge Phase 4 features.
+ *
+ * Tests breakpoints, checkpoints, and session replay functionality
+ * by spawning actual Codi and codi-debug processes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { spawn, type ChildProcess, execSync } from 'node:child_process';
+import { setupMockE2E, cleanupMockE2E, textResponse, toolResponse, toolCall, type MockE2ESession } from './helpers/mock-e2e.js';
+
+// Set longer timeout for E2E tests
+vi.setConfig({ testTimeout: 30000 });
+
+function distEntry(): string {
+  return path.resolve(process.cwd(), 'dist', 'index.js');
+}
+
+function debugCliEntry(): string {
+  return path.resolve(process.cwd(), 'dist', 'debug-cli.js');
+}
+
+function createTempProjectDir(): string {
+  const dir = path.join(os.tmpdir(), `codi-debug-e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanupTempDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+/**
+ * Process harness for E2E tests.
+ */
+class ProcessHarness {
+  private proc: ChildProcess;
+  private output = '';
+  private exitPromise: Promise<number | null>;
+
+  constructor(command: string, args: string[], opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) {
+    this.proc = spawn(command, args, {
+      cwd: opts?.cwd,
+      env: {
+        ...process.env,
+        ...opts?.env,
+        NO_COLOR: '1',
+        FORCE_COLOR: '0',
+        CI: '1',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    this.proc.stdout?.on('data', (data) => {
+      this.output += data.toString();
+    });
+
+    this.proc.stderr?.on('data', (data) => {
+      this.output += data.toString();
+    });
+
+    this.exitPromise = new Promise((resolve) => {
+      this.proc.on('exit', (code) => resolve(code));
+      this.proc.on('error', () => resolve(null));
+    });
+  }
+
+  write(data: string): void {
+    this.proc.stdin?.write(data);
+  }
+
+  writeLine(data: string): void {
+    this.write(data + '\n');
+  }
+
+  getOutput(): string {
+    return this.output;
+  }
+
+  clearOutput(): void {
+    this.output = '';
+  }
+
+  async waitFor(pattern: string | RegExp, timeoutMs = 15000): Promise<string> {
+    const re = typeof pattern === 'string'
+      ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      : pattern;
+
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (re.test(this.output)) {
+        return this.output;
+      }
+      await new Promise(r => setTimeout(r, 50));
+    }
+
+    throw new Error(`Timeout waiting for pattern: ${pattern}\n\nOutput:\n${this.output}`);
+  }
+
+  kill(): void {
+    this.proc.kill('SIGTERM');
+  }
+
+  async waitForExit(timeoutMs = 5000): Promise<number | null> {
+    const timeout = new Promise<number | null>((resolve) => {
+      setTimeout(() => {
+        this.kill();
+        resolve(null);
+      }, timeoutMs);
+    });
+
+    return Promise.race([this.exitPromise, timeout]);
+  }
+
+  get pid(): number | undefined {
+    return this.proc.pid;
+  }
+}
+
+describe('Debug Bridge E2E', () => {
+  let mockSession: MockE2ESession;
+  let projectDir: string;
+  let proc: ProcessHarness | null = null;
+  let debugDir: string;
+
+  beforeEach(() => {
+    projectDir = createTempProjectDir();
+    debugDir = path.join(projectDir, '.codi', 'debug');
+
+    // Set up mock responses for a simple conversation with tool use
+    mockSession = setupMockE2E([
+      toolResponse([toolCall('read_file', { path: 'test.txt' })]),
+      textResponse('I read the file and it contains test content.'),
+      textResponse('Goodbye!'),
+    ], { enableLogging: true });
+  });
+
+  afterEach(async () => {
+    if (proc) {
+      proc.kill();
+      await proc.waitForExit().catch(() => {});
+      proc = null;
+    }
+    cleanupMockE2E(mockSession);
+    cleanupTempDir(projectDir);
+  });
+
+  describe('Debug bridge startup', () => {
+    it('should start with --debug-bridge flag and create session', async () => {
+      // Create a test file
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      // Wait for debug bridge startup message
+      await proc.waitFor(/Debug bridge enabled/i);
+      await proc.waitFor(/Events:/i);
+      await proc.waitFor(/Session:/i);
+
+      // Verify session directory was created
+      await new Promise(r => setTimeout(r, 500));
+      expect(fs.existsSync(debugDir)).toBe(true);
+      expect(fs.existsSync(path.join(debugDir, 'sessions'))).toBe(true);
+
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+    });
+
+    it('should create events.jsonl with session_start event', async () => {
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      await proc.waitFor(/Debug bridge enabled/i);
+      await proc.waitFor(/Orchestrator: ready/i);
+
+      // Give time for events to be written
+      await new Promise(r => setTimeout(r, 500));
+
+      // Find the session directory
+      const sessionsDir = path.join(debugDir, 'sessions');
+      const sessions = fs.readdirSync(sessionsDir);
+      expect(sessions.length).toBeGreaterThan(0);
+
+      const sessionDir = path.join(sessionsDir, sessions[0]);
+      const eventsFile = path.join(sessionDir, 'events.jsonl');
+      expect(fs.existsSync(eventsFile)).toBe(true);
+
+      // Read and verify events
+      const content = fs.readFileSync(eventsFile, 'utf8');
+      const events = content.trim().split('\n').filter(l => l).map(l => JSON.parse(l));
+
+      // Should have at least session_start
+      const sessionStart = events.find(e => e.type === 'session_start');
+      expect(sessionStart).toBeDefined();
+      expect(sessionStart.data.provider.toLowerCase()).toBe('mock');
+
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+    });
+  });
+
+  describe('Breakpoint commands via codi-debug', () => {
+    it('should add breakpoint via codi-debug command', async () => {
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      await proc.waitFor(/Orchestrator: ready/i);
+      await new Promise(r => setTimeout(r, 500));
+
+      // Find the session
+      const sessionsDir = path.join(debugDir, 'sessions');
+      const sessions = fs.readdirSync(sessionsDir);
+      const sessionId = sessions[0];
+
+      // Run codi-debug to add breakpoint
+      const result = execSync(`${process.execPath} ${debugCliEntry()} breakpoint add tool read_file -s ${sessionId}`, {
+        cwd: projectDir,
+        env: {
+          ...process.env,
+          HOME: projectDir,
+          NO_COLOR: '1',
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result).toContain('Sent: breakpoint_add');
+
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+    });
+
+    it('should list breakpoints via codi-debug command', async () => {
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      await proc.waitFor(/Orchestrator: ready/i);
+      await new Promise(r => setTimeout(r, 500));
+
+      const sessionsDir = path.join(debugDir, 'sessions');
+      const sessions = fs.readdirSync(sessionsDir);
+      const sessionId = sessions[0];
+
+      // Add a breakpoint first
+      execSync(`${process.execPath} ${debugCliEntry()} breakpoint add tool write_file -s ${sessionId}`, {
+        cwd: projectDir,
+        env: { ...process.env, HOME: projectDir, NO_COLOR: '1' },
+        encoding: 'utf8',
+      });
+
+      // List breakpoints
+      const result = execSync(`${process.execPath} ${debugCliEntry()} breakpoint list -s ${sessionId}`, {
+        cwd: projectDir,
+        env: { ...process.env, HOME: projectDir, NO_COLOR: '1' },
+        encoding: 'utf8',
+      });
+
+      expect(result).toContain('Sent: breakpoint_list');
+
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+    });
+
+    it('should clear breakpoints via codi-debug command', async () => {
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      await proc.waitFor(/Orchestrator: ready/i);
+      await new Promise(r => setTimeout(r, 500));
+
+      const sessionsDir = path.join(debugDir, 'sessions');
+      const sessions = fs.readdirSync(sessionsDir);
+      const sessionId = sessions[0];
+
+      const result = execSync(`${process.execPath} ${debugCliEntry()} breakpoint clear -s ${sessionId}`, {
+        cwd: projectDir,
+        env: { ...process.env, HOME: projectDir, NO_COLOR: '1' },
+        encoding: 'utf8',
+      });
+
+      expect(result).toContain('Sent: breakpoint_clear');
+
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+    });
+  });
+
+  describe('Checkpoint commands via codi-debug', () => {
+    it('should create checkpoint via codi-debug command', async () => {
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      await proc.waitFor(/Orchestrator: ready/i);
+      await new Promise(r => setTimeout(r, 500));
+
+      const sessionsDir = path.join(debugDir, 'sessions');
+      const sessions = fs.readdirSync(sessionsDir);
+      const sessionId = sessions[0];
+
+      const result = execSync(`${process.execPath} ${debugCliEntry()} checkpoint create "test checkpoint" -s ${sessionId}`, {
+        cwd: projectDir,
+        env: { ...process.env, HOME: projectDir, NO_COLOR: '1' },
+        encoding: 'utf8',
+      });
+
+      expect(result).toContain('Sent: checkpoint_create');
+
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+    });
+
+    it('should list checkpoints via codi-debug command', async () => {
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      await proc.waitFor(/Orchestrator: ready/i);
+      await new Promise(r => setTimeout(r, 500));
+
+      const sessionsDir = path.join(debugDir, 'sessions');
+      const sessions = fs.readdirSync(sessionsDir);
+      const sessionId = sessions[0];
+
+      const result = execSync(`${process.execPath} ${debugCliEntry()} checkpoint list -s ${sessionId}`, {
+        cwd: projectDir,
+        env: { ...process.env, HOME: projectDir, NO_COLOR: '1' },
+        encoding: 'utf8',
+      });
+
+      expect(result).toContain('Sent: checkpoint_list');
+
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+    });
+  });
+
+  describe('Session replay', () => {
+    it('should replay session events', async () => {
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      // Start a session and generate some events
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+        '-y', // Auto-approve tools
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      await proc.waitFor(/Orchestrator: ready/i);
+
+      // Send a message to trigger tool use
+      proc.writeLine('read test.txt');
+
+      // Wait for tool execution
+      await proc.waitFor(/read_file/i, 10000);
+      await new Promise(r => setTimeout(r, 1000));
+
+      // Exit cleanly
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+      proc = null;
+
+      // Now replay the session
+      const sessionsDir = path.join(debugDir, 'sessions');
+      const sessions = fs.readdirSync(sessionsDir);
+      const sessionId = sessions[0];
+
+      const replayResult = execSync(`${process.execPath} ${debugCliEntry()} replay ${sessionId}`, {
+        cwd: projectDir,
+        env: { ...process.env, HOME: projectDir, NO_COLOR: '1' },
+        encoding: 'utf8',
+        timeout: 10000,
+      });
+
+      // Should show session events
+      expect(replayResult).toContain('SESSION START');
+      expect(replayResult).toContain('Replay complete');
+    });
+
+    it('should filter events during replay', async () => {
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+        '-y',
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      await proc.waitFor(/Orchestrator: ready/i);
+      proc.writeLine('read test.txt');
+      await proc.waitFor(/read_file/i, 10000);
+      await new Promise(r => setTimeout(r, 1000));
+
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+      proc = null;
+
+      const sessionsDir = path.join(debugDir, 'sessions');
+      const sessions = fs.readdirSync(sessionsDir);
+      const sessionId = sessions[0];
+
+      // Filter only for session start/end
+      const replayResult = execSync(`${process.execPath} ${debugCliEntry()} replay ${sessionId} --filter session_start,session_end`, {
+        cwd: projectDir,
+        env: { ...process.env, HOME: projectDir, NO_COLOR: '1' },
+        encoding: 'utf8',
+        timeout: 10000,
+      });
+
+      expect(replayResult).toContain('SESSION START');
+      // Should NOT contain tool events when filtered
+      expect(replayResult).not.toContain('TOOL START');
+    });
+  });
+
+  describe('Pause/Resume with breakpoints', () => {
+    it('should pause and resume via codi-debug', async () => {
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      await proc.waitFor(/Orchestrator: ready/i);
+      await new Promise(r => setTimeout(r, 500));
+
+      const sessionsDir = path.join(debugDir, 'sessions');
+      const sessions = fs.readdirSync(sessionsDir);
+      const sessionId = sessions[0];
+
+      // Pause
+      const pauseResult = execSync(`${process.execPath} ${debugCliEntry()} pause -s ${sessionId}`, {
+        cwd: projectDir,
+        env: { ...process.env, HOME: projectDir, NO_COLOR: '1' },
+        encoding: 'utf8',
+      });
+      expect(pauseResult).toContain('Sent: pause');
+
+      // Resume
+      const resumeResult = execSync(`${process.execPath} ${debugCliEntry()} resume -s ${sessionId}`, {
+        cwd: projectDir,
+        env: { ...process.env, HOME: projectDir, NO_COLOR: '1' },
+        encoding: 'utf8',
+      });
+      expect(resumeResult).toContain('Sent: resume');
+
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+    });
+  });
+
+  describe('Sessions command', () => {
+    it('should list sessions via codi-debug', async () => {
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      await proc.waitFor(/Orchestrator: ready/i);
+      await new Promise(r => setTimeout(r, 500));
+
+      const result = execSync(`${process.execPath} ${debugCliEntry()} sessions -a`, {
+        cwd: projectDir,
+        env: { ...process.env, HOME: projectDir, NO_COLOR: '1' },
+        encoding: 'utf8',
+      });
+
+      // Should list the active session
+      expect(result).toContain('Debug Sessions');
+      expect(result).toContain('debug_');
+
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+    });
+  });
+
+  describe('Status command', () => {
+    it('should show status via codi-debug', async () => {
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      await proc.waitFor(/Orchestrator: ready/i);
+      await new Promise(r => setTimeout(r, 500));
+
+      const sessionsDir = path.join(debugDir, 'sessions');
+      const sessions = fs.readdirSync(sessionsDir);
+      const sessionId = sessions[0];
+
+      const result = execSync(`${process.execPath} ${debugCliEntry()} status -s ${sessionId}`, {
+        cwd: projectDir,
+        env: { ...process.env, HOME: projectDir, NO_COLOR: '1' },
+        encoding: 'utf8',
+      });
+
+      expect(result).toContain('Session Status');
+      expect(result).toContain('ACTIVE');
+      expect(result).toContain('Events:');
+
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+    });
+  });
+
+  describe('Inspect command', () => {
+    it('should inspect via codi-debug', async () => {
+      fs.writeFileSync(path.join(projectDir, 'test.txt'), 'test content');
+
+      proc = new ProcessHarness(process.execPath, [
+        distEntry(),
+        '--provider', 'mock',
+        '--debug-bridge',
+      ], {
+        cwd: projectDir,
+        env: {
+          ...mockSession.env,
+          HOME: projectDir,
+        },
+      });
+
+      await proc.waitFor(/Orchestrator: ready/i);
+      await new Promise(r => setTimeout(r, 500));
+
+      const sessionsDir = path.join(debugDir, 'sessions');
+      const sessions = fs.readdirSync(sessionsDir);
+      const sessionId = sessions[0];
+
+      const result = execSync(`${process.execPath} ${debugCliEntry()} inspect all -s ${sessionId}`, {
+        cwd: projectDir,
+        env: { ...process.env, HOME: projectDir, NO_COLOR: '1' },
+        encoding: 'utf8',
+      });
+
+      expect(result).toContain('Sent: inspect');
+
+      proc.writeLine('/exit');
+      await proc.waitForExit();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds comprehensive e2e tests for Debug Bridge Phase 4 features.

## Tests Added (13 tests)

### Debug bridge startup
- Should start with --debug-bridge flag and create session
- Should create events.jsonl with session_start event

### Breakpoint commands
- Should add breakpoint via codi-debug command
- Should list breakpoints via codi-debug command
- Should clear breakpoints via codi-debug command

### Checkpoint commands
- Should create checkpoint via codi-debug command
- Should list checkpoints via codi-debug command

### Session replay
- Should replay session events
- Should filter events during replay

### Control commands
- Should pause and resume via codi-debug
- Should list sessions via codi-debug
- Should show status via codi-debug
- Should inspect via codi-debug

## Test plan
- [x] All 13 e2e tests pass
- [x] Tests spawn real Codi process with --debug-bridge
- [x] Tests use codi-debug CLI to interact with session

🤖 Generated with [Claude Code](https://claude.com/claude-code)