### PR TITLE
docs: clarify Windows is not supported (use WSL2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,9 @@ pnpm link --global
 <details>
 <summary><strong>Windows</strong></summary>
 
-- Use PowerShell or Windows Terminal (not cmd.exe)
-- Git Bash works but may have readline issues
-- WSL2 recommended for best experience
-- Path separator differences are handled automatically
+**Windows is not currently supported.** We recommend using WSL2 (Windows Subsystem for Linux) for the best experience.
 
-**Known limitations:**
-- PTY-based tests are skipped
-- Some bash commands may need Windows equivalents
+See [GitHub issue #134](https://github.com/laynepenney/codi/issues/134) for details.
 
 </details>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@ Codi is a feature-rich AI coding assistant CLI. This document tracks completed w
 
 ### High Priority
 
-- [ ] **Windows CI runner** - Test native module compilation on Windows (see #134)
+- [ ] **Windows support** - Not currently supported; use WSL2 (see #134)
 - [ ] **npm publish workflow** - Automated releases on tag push (`.github/workflows/release.yml`)
 - [ ] **Command unit tests** - memory-commands, orchestrate-commands, rag-commands, compact-commands
 

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -11,7 +11,7 @@ Based on comprehensive codebase analysis, codi is **85-90% production ready**. T
 1. **Testing** - Core modules (agent.ts, MCP server, orchestration) lack unit tests
 2. **Security** - Path traversal vulnerabilities, dependency vulnerabilities (7 moderate)
 3. **Memory** - Unbounded message accumulation and working set growth
-4. **Deployment** - No npm publish workflow, Windows untested
+4. **Deployment** - No npm publish workflow (Windows not supported - use WSL2)
 
 ---
 
@@ -72,8 +72,8 @@ if (!resolvedPath.startsWith(projectRoot + '/') && resolvedPath !== projectRoot)
 #### 2.2 CI/CD Enhancements
 **File:** `.github/workflows/ci.yml`
 
-- [ ] Add macOS runner for cross-platform testing
-- [ ] Add Windows runner (test native module compilation)
+- [x] Add macOS runner for cross-platform testing
+- [ ] ~~Add Windows runner~~ - Not supported; use WSL2 (see #134)
 - [ ] Add npm publish workflow triggered by tags
 
 **New file:** `.github/workflows/release.yml`
@@ -159,7 +159,6 @@ RUNPOD_API_KEY=...
 
 - [ ] Add npm installation method: `npm install -g codi`
 - [ ] Add troubleshooting section
-- [ ] Add Windows-specific notes
 - [ ] Add provider setup guides
 
 ---
@@ -218,7 +217,7 @@ RUNPOD_API_KEY=...
 ### High (Tier 2)
 | File | Change |
 |------|--------|
-| `.github/workflows/ci.yml` | Add macOS, Windows runners |
+| `.github/workflows/ci.yml` | Add macOS runner (Windows not supported) |
 | `.github/workflows/release.yml` | New publish workflow |
 | `package.json` | Add files, publishConfig |
 | `.env.example` | New file |
@@ -241,7 +240,7 @@ RUNPOD_API_KEY=...
 - [ ] All 7 dependency vulnerabilities resolved (`pnpm audit` shows 0)
 - [ ] Path traversal tests pass (attempt to read `/etc/passwd` fails)
 - [ ] Memory stays bounded in 2-hour stress test
-- [ ] CI passes on Ubuntu, macOS, Windows
+- [ ] CI passes on Ubuntu and macOS (Windows not supported - use WSL2)
 - [ ] npm publish workflow tested with dry-run
 
 ### Before GA Release
@@ -272,7 +271,7 @@ RUNPOD_API_KEY=...
 | Path traversal exploit | Medium | Critical | Tier 1.2 path validation |
 | Memory exhaustion in long sessions | High | High | Tier 1.4 bounds |
 | Database corruption on crash | Medium | High | Tier 1.3 exit handlers |
-| Windows compatibility issues | Medium | Medium | Tier 2.2 CI testing |
+| Windows compatibility issues | N/A | N/A | Not supported - use WSL2 (#134) |
 | npm publish failures | Low | Medium | Tier 2.3 workflow |
 
 ---


### PR DESCRIPTION
## Summary

Update documentation to reflect that Windows is not currently supported. Users should use WSL2 for Windows development.

## Changes

- **README.md**: Replace detailed Windows instructions with WSL2 recommendation
- **ROADMAP.md**: Update Windows CI item to reflect non-support status
- **PRODUCTION-READINESS.md**: Remove Windows from CI targets, checklists, and risk table

## Related

- References: #134 (Windows CI issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)