### PR TITLE
fix(test): isolate HOME in E2E tests to prevent config interference

### DIFF
--- a/tests/code-commands.e2e.test.ts
+++ b/tests/code-commands.e2e.test.ts
@@ -6,22 +6,13 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { spawn, type ChildProcess } from 'node:child_process';
+import * as path from 'node:path';
 import { setupMockE2E, cleanupMockE2E, textResponse, type MockE2ESession } from './helpers/mock-e2e.js';
-
-// Platform-aware timeouts - macOS CI is slower
-const isMacOS = process.platform === 'darwin';
-const TEST_TIMEOUT = isMacOS ? 90000 : 20000;
-const WAIT_TIMEOUT = isMacOS ? 60000 : 15000;
+import { ProcessHarness, TEST_TIMEOUT, distEntry } from './helpers/process-harness.js';
 
 vi.setConfig({ testTimeout: TEST_TIMEOUT });
-
-function distEntry(): string {
-  return path.resolve(process.cwd(), 'dist', 'index.js');
-}
 
 function createTempProjectDir(): string {
   const dir = path.join(os.tmpdir(), `codi-code-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
@@ -34,52 +25,6 @@ function cleanupTempDir(dir: string): void {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch {
     // Ignore cleanup errors
-  }
-}
-
-class ProcessHarness {
-  private proc: ChildProcess;
-  private output = '';
-  private exitPromise: Promise<number | null>;
-
-  constructor(command: string, args: string[], opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) {
-    this.proc = spawn(command, args, {
-      cwd: opts?.cwd,
-      env: { ...process.env, ...opts?.env, NO_COLOR: '1', FORCE_COLOR: '0', CI: '1' },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    this.proc.stdout?.on('data', (data) => { this.output += data.toString(); });
-    this.proc.stderr?.on('data', (data) => { this.output += data.toString(); });
-
-    this.exitPromise = new Promise((resolve) => {
-      this.proc.on('exit', (code) => resolve(code));
-      this.proc.on('error', () => resolve(null));
-    });
-  }
-
-  writeLine(data: string): void { this.proc.stdin?.write(data + '\n'); }
-  getOutput(): string { return this.output; }
-
-  async waitFor(pattern: string | RegExp, timeoutMs = WAIT_TIMEOUT): Promise<string> {
-    const re = typeof pattern === 'string'
-      ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-      : pattern;
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (re.test(this.output)) return this.output;
-      await new Promise(r => setTimeout(r, 50));
-    }
-    throw new Error(`Timeout waiting for pattern: ${pattern}\n\nOutput:\n${this.output}`);
-  }
-
-  kill(): void { this.proc.kill('SIGTERM'); }
-
-  async waitForExit(timeoutMs = 5000): Promise<number | null> {
-    const timeout = new Promise<number | null>((resolve) => {
-      setTimeout(() => { this.kill(); resolve(null); }, timeoutMs);
-    });
-    return Promise.race([this.exitPromise, timeout]);
   }
 }
 

--- a/tests/commands.e2e.test.ts
+++ b/tests/commands.e2e.test.ts
@@ -8,23 +8,14 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-
-// Platform-aware timeouts - macOS CI is slower
-const isMacOS = process.platform === 'darwin';
-const TEST_TIMEOUT = isMacOS ? 90000 : 20000;
-const WAIT_TIMEOUT = isMacOS ? 60000 : 15000;
-
-// Set longer timeout for E2E tests
-vi.setConfig({ testTimeout: TEST_TIMEOUT });
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { spawn, type ChildProcess } from 'node:child_process';
 import { setupMockE2E, cleanupMockE2E, textResponse, type MockE2ESession } from './helpers/mock-e2e.js';
+import { ProcessHarness, TEST_TIMEOUT, distEntry } from './helpers/process-harness.js';
 
-function distEntry(): string {
-  return path.resolve(process.cwd(), 'dist', 'index.js');
-}
+// Set longer timeout for E2E tests
+vi.setConfig({ testTimeout: TEST_TIMEOUT });
 
 function createTempProjectDir(): string {
   const dir = path.join(os.tmpdir(), `codi-cmd-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
@@ -37,85 +28,6 @@ function cleanupTempDir(dir: string): void {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch {
     // Ignore cleanup errors
-  }
-}
-
-/**
- * Process harness for E2E tests without PTY.
- */
-class ProcessHarness {
-  private proc: ChildProcess;
-  private output = '';
-  private exitPromise: Promise<number | null>;
-
-  constructor(command: string, args: string[], opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) {
-    this.proc = spawn(command, args, {
-      cwd: opts?.cwd,
-      env: {
-        ...process.env,
-        ...opts?.env,
-        NO_COLOR: '1',
-        FORCE_COLOR: '0',
-        CI: '1',
-      },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    this.proc.stdout?.on('data', (data) => {
-      this.output += data.toString();
-    });
-
-    this.proc.stderr?.on('data', (data) => {
-      this.output += data.toString();
-    });
-
-    this.exitPromise = new Promise((resolve) => {
-      this.proc.on('exit', (code) => resolve(code));
-      this.proc.on('error', () => resolve(null));
-    });
-  }
-
-  write(data: string): void {
-    this.proc.stdin?.write(data);
-  }
-
-  writeLine(data: string): void {
-    this.write(data + '\n');
-  }
-
-  getOutput(): string {
-    return this.output;
-  }
-
-  async waitFor(pattern: string | RegExp, timeoutMs = WAIT_TIMEOUT): Promise<string> {
-    const re = typeof pattern === 'string'
-      ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-      : pattern;
-
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (re.test(this.output)) {
-        return this.output;
-      }
-      await new Promise(r => setTimeout(r, 50));
-    }
-
-    throw new Error(`Timeout waiting for pattern: ${pattern}\n\nOutput:\n${this.output}`);
-  }
-
-  kill(): void {
-    this.proc.kill('SIGTERM');
-  }
-
-  async waitForExit(timeoutMs = 5000): Promise<number | null> {
-    const timeout = new Promise<number | null>((resolve) => {
-      setTimeout(() => {
-        this.kill();
-        resolve(null);
-      }, timeoutMs);
-    });
-
-    return Promise.race([this.exitPromise, timeout]);
   }
 }
 

--- a/tests/git-commands.e2e.test.ts
+++ b/tests/git-commands.e2e.test.ts
@@ -6,22 +6,14 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { spawn, type ChildProcess, execSync } from 'node:child_process';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
 import { setupMockE2E, cleanupMockE2E, textResponse, type MockE2ESession } from './helpers/mock-e2e.js';
-
-// Platform-aware timeouts - macOS CI is slower
-const isMacOS = process.platform === 'darwin';
-const TEST_TIMEOUT = isMacOS ? 90000 : 20000;
-const WAIT_TIMEOUT = isMacOS ? 60000 : 15000;
+import { ProcessHarness, TEST_TIMEOUT, distEntry } from './helpers/process-harness.js';
 
 vi.setConfig({ testTimeout: TEST_TIMEOUT });
-
-function distEntry(): string {
-  return path.resolve(process.cwd(), 'dist', 'index.js');
-}
 
 function createTempGitDir(): string {
   const dir = path.join(os.tmpdir(), `codi-git-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
@@ -38,52 +30,6 @@ function cleanupTempDir(dir: string): void {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch {
     // Ignore cleanup errors
-  }
-}
-
-class ProcessHarness {
-  private proc: ChildProcess;
-  private output = '';
-  private exitPromise: Promise<number | null>;
-
-  constructor(command: string, args: string[], opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) {
-    this.proc = spawn(command, args, {
-      cwd: opts?.cwd,
-      env: { ...process.env, ...opts?.env, NO_COLOR: '1', FORCE_COLOR: '0', CI: '1' },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    this.proc.stdout?.on('data', (data) => { this.output += data.toString(); });
-    this.proc.stderr?.on('data', (data) => { this.output += data.toString(); });
-
-    this.exitPromise = new Promise((resolve) => {
-      this.proc.on('exit', (code) => resolve(code));
-      this.proc.on('error', () => resolve(null));
-    });
-  }
-
-  writeLine(data: string): void { this.proc.stdin?.write(data + '\n'); }
-  getOutput(): string { return this.output; }
-
-  async waitFor(pattern: string | RegExp, timeoutMs = WAIT_TIMEOUT): Promise<string> {
-    const re = typeof pattern === 'string'
-      ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-      : pattern;
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (re.test(this.output)) return this.output;
-      await new Promise(r => setTimeout(r, 50));
-    }
-    throw new Error(`Timeout waiting for pattern: ${pattern}\n\nOutput:\n${this.output}`);
-  }
-
-  kill(): void { this.proc.kill('SIGTERM'); }
-
-  async waitForExit(timeoutMs = 5000): Promise<number | null> {
-    const timeout = new Promise<number | null>((resolve) => {
-      setTimeout(() => { this.kill(); resolve(null); }, timeoutMs);
-    });
-    return Promise.race([this.exitPromise, timeout]);
   }
 }
 

--- a/tests/helpers/process-harness.ts
+++ b/tests/helpers/process-harness.ts
@@ -1,0 +1,131 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Shared ProcessHarness for E2E tests.
+ *
+ * Automatically isolates HOME to prevent loading user's global config.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Platform-aware timeouts - macOS CI is slower
+const isMacOS = process.platform === 'darwin';
+export const TEST_TIMEOUT = isMacOS ? 90000 : 20000;
+export const WAIT_TIMEOUT = isMacOS ? 60000 : 15000;
+
+/**
+ * Get the path to the built codi entry point.
+ */
+export function distEntry(): string {
+  return path.resolve(process.cwd(), 'dist', 'index.js');
+}
+
+/**
+ * Process harness for E2E testing of the CLI.
+ *
+ * Key features:
+ * - Automatically isolates HOME to prevent loading user's global config
+ * - Captures stdout and stderr
+ * - Provides waitFor() for pattern matching
+ * - Manages temp directories
+ */
+export class ProcessHarness {
+  private proc: ChildProcess;
+  private output = '';
+  private exitPromise: Promise<number | null>;
+  private tempHome: string | null;
+
+  constructor(command: string, args: string[], opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) {
+    // Create isolated HOME directory to prevent loading user's global config
+    // Only if the test doesn't provide its own HOME
+    const userProvidedHome = opts?.env?.HOME || opts?.env?.USERPROFILE;
+    if (userProvidedHome) {
+      // User manages their own HOME
+      this.tempHome = null;
+    } else {
+      // Create isolated temp HOME
+      this.tempHome = path.join(os.tmpdir(), `codi-e2e-home-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+      fs.mkdirSync(this.tempHome, { recursive: true });
+    }
+
+    this.proc = spawn(command, args, {
+      cwd: opts?.cwd,
+      env: {
+        ...process.env,
+        // Set default isolated HOME if we created one
+        ...(this.tempHome ? { HOME: this.tempHome, USERPROFILE: this.tempHome } : {}),
+        ...opts?.env, // User env comes after to allow overriding
+        NO_COLOR: '1',
+        FORCE_COLOR: '0',
+        CI: '1',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    this.proc.stdout?.on('data', (data) => { this.output += data.toString(); });
+    this.proc.stderr?.on('data', (data) => { this.output += data.toString(); });
+
+    this.exitPromise = new Promise((resolve) => {
+      this.proc.on('exit', (code) => resolve(code));
+      this.proc.on('error', () => resolve(null));
+    });
+  }
+
+  write(data: string): void {
+    this.proc.stdin?.write(data);
+  }
+
+  writeLine(data: string): void {
+    this.write(data + '\n');
+  }
+
+  getOutput(): string {
+    return this.output;
+  }
+
+  clearOutput(): void {
+    this.output = '';
+  }
+
+  get pid(): number | undefined {
+    return this.proc.pid;
+  }
+
+  async waitFor(pattern: string | RegExp, timeoutMs = WAIT_TIMEOUT): Promise<string> {
+    const re = typeof pattern === 'string'
+      ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      : pattern;
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (re.test(this.output)) return this.output;
+      await new Promise(r => setTimeout(r, 50));
+    }
+    throw new Error(`Timeout waiting for pattern: ${pattern}\n\nOutput:\n${this.output}`);
+  }
+
+  kill(): void {
+    this.proc.kill('SIGTERM');
+  }
+
+  async waitForExit(timeoutMs = 5000): Promise<number | null> {
+    const timeout = new Promise<number | null>((resolve) => {
+      setTimeout(() => { this.kill(); resolve(null); }, timeoutMs);
+    });
+    const result = await Promise.race([this.exitPromise, timeout]);
+
+    // Cleanup temp home directory (only if we created it)
+    if (this.tempHome) {
+      try {
+        fs.rmSync(this.tempHome, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+
+    return result;
+  }
+}

--- a/tests/init-command.e2e.test.ts
+++ b/tests/init-command.e2e.test.ts
@@ -11,23 +11,13 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-
-// Platform-aware timeouts - macOS CI is slower
-const isMacOS = process.platform === 'darwin';
-const TEST_TIMEOUT = isMacOS ? 90000 : 20000;
-const WAIT_TIMEOUT = isMacOS ? 60000 : 15000;
-
-vi.setConfig({ testTimeout: TEST_TIMEOUT });
-
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { spawn, type ChildProcess } from 'node:child_process';
 import { setupMockE2E, cleanupMockE2E, textResponse, type MockE2ESession } from './helpers/mock-e2e.js';
+import { ProcessHarness, TEST_TIMEOUT, distEntry } from './helpers/process-harness.js';
 
-function distEntry(): string {
-  return path.resolve(process.cwd(), 'dist', 'index.js');
-}
+vi.setConfig({ testTimeout: TEST_TIMEOUT });
 
 function createTempProjectDir(): string {
   const dir = path.join(os.tmpdir(), `codi-init-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
@@ -40,86 +30,6 @@ function cleanupTempDir(dir: string): void {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch {
     // Ignore cleanup errors
-  }
-}
-
-/**
- * Simple process harness for E2E tests without PTY.
- */
-class ProcessHarness {
-  private proc: ChildProcess;
-  private output = '';
-  private exitPromise: Promise<number | null>;
-
-  constructor(command: string, args: string[], opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) {
-    this.proc = spawn(command, args, {
-      cwd: opts?.cwd,
-      env: {
-        ...process.env,
-        ...opts?.env,
-        // Disable colors and interactive features
-        NO_COLOR: '1',
-        FORCE_COLOR: '0',
-        CI: '1',
-      },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    this.proc.stdout?.on('data', (data) => {
-      this.output += data.toString();
-    });
-
-    this.proc.stderr?.on('data', (data) => {
-      this.output += data.toString();
-    });
-
-    this.exitPromise = new Promise((resolve) => {
-      this.proc.on('exit', (code) => resolve(code));
-      this.proc.on('error', () => resolve(null));
-    });
-  }
-
-  write(data: string): void {
-    this.proc.stdin?.write(data);
-  }
-
-  writeLine(data: string): void {
-    this.write(data + '\n');
-  }
-
-  getOutput(): string {
-    return this.output;
-  }
-
-  async waitFor(pattern: string | RegExp, timeoutMs = WAIT_TIMEOUT): Promise<string> {
-    const re = typeof pattern === 'string'
-      ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-      : pattern;
-
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (re.test(this.output)) {
-        return this.output;
-      }
-      await new Promise(r => setTimeout(r, 50));
-    }
-
-    throw new Error(`Timeout waiting for pattern: ${pattern}\n\nOutput:\n${this.output}`);
-  }
-
-  kill(): void {
-    this.proc.kill('SIGTERM');
-  }
-
-  async waitForExit(timeoutMs = 5000): Promise<number | null> {
-    const timeout = new Promise<number | null>((resolve) => {
-      setTimeout(() => {
-        this.kill();
-        resolve(null);
-      }, timeoutMs);
-    });
-
-    return Promise.race([this.exitPromise, timeout]);
   }
 }
 

--- a/tests/more-tools.e2e.test.ts
+++ b/tests/more-tools.e2e.test.ts
@@ -9,7 +9,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { spawn, type ChildProcess } from 'node:child_process';
 import {
   setupMockE2E,
   cleanupMockE2E,
@@ -18,17 +17,9 @@ import {
   toolCall,
   type MockE2ESession,
 } from './helpers/mock-e2e.js';
-
-// Platform-aware timeouts - macOS CI is slower
-const isMacOS = process.platform === 'darwin';
-const TEST_TIMEOUT = isMacOS ? 90000 : 20000;
-const WAIT_TIMEOUT = isMacOS ? 60000 : 15000;
+import { ProcessHarness, TEST_TIMEOUT, distEntry } from './helpers/process-harness.js';
 
 vi.setConfig({ testTimeout: TEST_TIMEOUT });
-
-function distEntry(): string {
-  return path.resolve(process.cwd(), 'dist', 'index.js');
-}
 
 function createTempProjectDir(): string {
   const dir = path.join(os.tmpdir(), `codi-more-tools-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
@@ -41,52 +32,6 @@ function cleanupTempDir(dir: string): void {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch {
     // Ignore cleanup errors
-  }
-}
-
-class ProcessHarness {
-  private proc: ChildProcess;
-  private output = '';
-  private exitPromise: Promise<number | null>;
-
-  constructor(command: string, args: string[], opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) {
-    this.proc = spawn(command, args, {
-      cwd: opts?.cwd,
-      env: { ...process.env, ...opts?.env, NO_COLOR: '1', FORCE_COLOR: '0', CI: '1' },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    this.proc.stdout?.on('data', (data) => { this.output += data.toString(); });
-    this.proc.stderr?.on('data', (data) => { this.output += data.toString(); });
-
-    this.exitPromise = new Promise((resolve) => {
-      this.proc.on('exit', (code) => resolve(code));
-      this.proc.on('error', () => resolve(null));
-    });
-  }
-
-  writeLine(data: string): void { this.proc.stdin?.write(data + '\n'); }
-  getOutput(): string { return this.output; }
-
-  async waitFor(pattern: string | RegExp, timeoutMs = WAIT_TIMEOUT): Promise<string> {
-    const re = typeof pattern === 'string'
-      ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-      : pattern;
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (re.test(this.output)) return this.output;
-      await new Promise(r => setTimeout(r, 50));
-    }
-    throw new Error(`Timeout waiting for pattern: ${pattern}\n\nOutput:\n${this.output}`);
-  }
-
-  kill(): void { this.proc.kill('SIGTERM'); }
-
-  async waitForExit(timeoutMs = 5000): Promise<number | null> {
-    const timeout = new Promise<number | null>((resolve) => {
-      setTimeout(() => { this.kill(); resolve(null); }, timeoutMs);
-    });
-    return Promise.race([this.exitPromise, timeout]);
   }
 }
 

--- a/tests/session-commands.e2e.test.ts
+++ b/tests/session-commands.e2e.test.ts
@@ -9,19 +9,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { spawn, type ChildProcess } from 'node:child_process';
 import { setupMockE2E, cleanupMockE2E, textResponse, type MockE2ESession } from './helpers/mock-e2e.js';
-
-// Platform-aware timeouts - macOS CI is slower
-const isMacOS = process.platform === 'darwin';
-const TEST_TIMEOUT = isMacOS ? 90000 : 20000;
-const WAIT_TIMEOUT = isMacOS ? 60000 : 15000;
+import { ProcessHarness, TEST_TIMEOUT, distEntry } from './helpers/process-harness.js';
 
 vi.setConfig({ testTimeout: TEST_TIMEOUT });
-
-function distEntry(): string {
-  return path.resolve(process.cwd(), 'dist', 'index.js');
-}
 
 function createTempProjectDir(): string {
   const dir = path.join(os.tmpdir(), `codi-session-e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
@@ -40,52 +31,6 @@ function cleanupTempDir(dir: string): void {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch {
     // Ignore cleanup errors
-  }
-}
-
-class ProcessHarness {
-  private proc: ChildProcess;
-  private output = '';
-  private exitPromise: Promise<number | null>;
-
-  constructor(command: string, args: string[], opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) {
-    this.proc = spawn(command, args, {
-      cwd: opts?.cwd,
-      env: { ...process.env, ...opts?.env, NO_COLOR: '1', FORCE_COLOR: '0', CI: '1' },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    this.proc.stdout?.on('data', (data) => { this.output += data.toString(); });
-    this.proc.stderr?.on('data', (data) => { this.output += data.toString(); });
-
-    this.exitPromise = new Promise((resolve) => {
-      this.proc.on('exit', (code) => resolve(code));
-      this.proc.on('error', () => resolve(null));
-    });
-  }
-
-  writeLine(data: string): void { this.proc.stdin?.write(data + '\n'); }
-  getOutput(): string { return this.output; }
-
-  async waitFor(pattern: string | RegExp, timeoutMs = WAIT_TIMEOUT): Promise<string> {
-    const re = typeof pattern === 'string'
-      ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-      : pattern;
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (re.test(this.output)) return this.output;
-      await new Promise(r => setTimeout(r, 50));
-    }
-    throw new Error(`Timeout waiting for pattern: ${pattern}\n\nOutput:\n${this.output}`);
-  }
-
-  kill(): void { this.proc.kill('SIGTERM'); }
-
-  async waitForExit(timeoutMs = 5000): Promise<number | null> {
-    const timeout = new Promise<number | null>((resolve) => {
-      setTimeout(() => { this.kill(); resolve(null); }, timeoutMs);
-    });
-    return Promise.race([this.exitPromise, timeout]);
   }
 }
 

--- a/tests/tools.e2e.test.ts
+++ b/tests/tools.e2e.test.ts
@@ -8,18 +8,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-
-// Platform-aware timeouts - macOS CI is slower
-const isMacOS = process.platform === 'darwin';
-const TEST_TIMEOUT = isMacOS ? 90000 : 20000;
-const WAIT_TIMEOUT = isMacOS ? 60000 : 15000;
-
-// Set longer timeout for E2E tests
-vi.setConfig({ testTimeout: TEST_TIMEOUT });
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { spawn, type ChildProcess } from 'node:child_process';
 import {
   setupMockE2E,
   cleanupMockE2E,
@@ -29,10 +20,10 @@ import {
   conversationSequence,
   type MockE2ESession,
 } from './helpers/mock-e2e.js';
+import { ProcessHarness, TEST_TIMEOUT, distEntry } from './helpers/process-harness.js';
 
-function distEntry(): string {
-  return path.resolve(process.cwd(), 'dist', 'index.js');
-}
+// Set longer timeout for E2E tests
+vi.setConfig({ testTimeout: TEST_TIMEOUT });
 
 function createTempProjectDir(): string {
   const dir = path.join(os.tmpdir(), `codi-tool-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
@@ -45,85 +36,6 @@ function cleanupTempDir(dir: string): void {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch {
     // Ignore cleanup errors
-  }
-}
-
-/**
- * Process harness for E2E tests without PTY.
- */
-class ProcessHarness {
-  private proc: ChildProcess;
-  private output = '';
-  private exitPromise: Promise<number | null>;
-
-  constructor(command: string, args: string[], opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) {
-    this.proc = spawn(command, args, {
-      cwd: opts?.cwd,
-      env: {
-        ...process.env,
-        ...opts?.env,
-        NO_COLOR: '1',
-        FORCE_COLOR: '0',
-        CI: '1',
-      },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    this.proc.stdout?.on('data', (data) => {
-      this.output += data.toString();
-    });
-
-    this.proc.stderr?.on('data', (data) => {
-      this.output += data.toString();
-    });
-
-    this.exitPromise = new Promise((resolve) => {
-      this.proc.on('exit', (code) => resolve(code));
-      this.proc.on('error', () => resolve(null));
-    });
-  }
-
-  write(data: string): void {
-    this.proc.stdin?.write(data);
-  }
-
-  writeLine(data: string): void {
-    this.write(data + '\n');
-  }
-
-  getOutput(): string {
-    return this.output;
-  }
-
-  async waitFor(pattern: string | RegExp, timeoutMs = WAIT_TIMEOUT): Promise<string> {
-    const re = typeof pattern === 'string'
-      ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-      : pattern;
-
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (re.test(this.output)) {
-        return this.output;
-      }
-      await new Promise(r => setTimeout(r, 50));
-    }
-
-    throw new Error(`Timeout waiting for pattern: ${pattern}\n\nOutput:\n${this.output}`);
-  }
-
-  kill(): void {
-    this.proc.kill('SIGTERM');
-  }
-
-  async waitForExit(timeoutMs = 5000): Promise<number | null> {
-    const timeout = new Promise<number | null>((resolve) => {
-      setTimeout(() => {
-        this.kill();
-        resolve(null);
-      }, timeoutMs);
-    });
-
-    return Promise.race([this.exitPromise, timeout]);
   }
 }
 

--- a/tests/workflow-commands.e2e.test.ts
+++ b/tests/workflow-commands.e2e.test.ts
@@ -6,25 +6,16 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { spawn, type ChildProcess } from 'node:child_process';
+import * as path from 'node:path';
 import { setupMockE2E, cleanupMockE2E, textResponse, type MockE2ESession } from './helpers/mock-e2e.js';
+import { ProcessHarness, TEST_TIMEOUT, distEntry } from './helpers/process-harness.js';
 
 // Skip orchestrator tests on Windows (Unix domain sockets not supported)
 const isWindows = process.platform === 'win32';
 
-// Platform-aware timeouts - macOS CI is slower
-const isMacOS = process.platform === 'darwin';
-const TEST_TIMEOUT = isMacOS ? 90000 : 20000;
-const WAIT_TIMEOUT = isMacOS ? 60000 : 15000;
-
 vi.setConfig({ testTimeout: TEST_TIMEOUT });
-
-function distEntry(): string {
-  return path.resolve(process.cwd(), 'dist', 'index.js');
-}
 
 function createTempProjectDir(): string {
   const dir = path.join(os.tmpdir(), `codi-workflow-e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
@@ -37,52 +28,6 @@ function cleanupTempDir(dir: string): void {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch {
     // Ignore cleanup errors
-  }
-}
-
-class ProcessHarness {
-  private proc: ChildProcess;
-  private output = '';
-  private exitPromise: Promise<number | null>;
-
-  constructor(command: string, args: string[], opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) {
-    this.proc = spawn(command, args, {
-      cwd: opts?.cwd,
-      env: { ...process.env, ...opts?.env, NO_COLOR: '1', FORCE_COLOR: '0', CI: '1' },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    this.proc.stdout?.on('data', (data) => { this.output += data.toString(); });
-    this.proc.stderr?.on('data', (data) => { this.output += data.toString(); });
-
-    this.exitPromise = new Promise((resolve) => {
-      this.proc.on('exit', (code) => resolve(code));
-      this.proc.on('error', () => resolve(null));
-    });
-  }
-
-  writeLine(data: string): void { this.proc.stdin?.write(data + '\n'); }
-  getOutput(): string { return this.output; }
-
-  async waitFor(pattern: string | RegExp, timeoutMs = WAIT_TIMEOUT): Promise<string> {
-    const re = typeof pattern === 'string'
-      ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-      : pattern;
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (re.test(this.output)) return this.output;
-      await new Promise(r => setTimeout(r, 50));
-    }
-    throw new Error(`Timeout waiting for pattern: ${pattern}\n\nOutput:\n${this.output}`);
-  }
-
-  kill(): void { this.proc.kill('SIGTERM'); }
-
-  async waitForExit(timeoutMs = 5000): Promise<number | null> {
-    const timeout = new Promise<number | null>((resolve) => {
-      setTimeout(() => { this.kill(); resolve(null); }, timeoutMs);
-    });
-    return Promise.race([this.exitPromise, timeout]);
   }
 }
 


### PR DESCRIPTION
## Summary

- Creates a shared `ProcessHarness` in `tests/helpers/process-harness.ts` that automatically isolates HOME directory to prevent loading user's global config
- Updates all E2E test files to use the shared ProcessHarness
- Reduces code duplication (~650 lines removed)

## Problem

E2E tests were failing on macOS CI because they loaded the user's global config from `~/.codi/config.json`. The global config had model map routing that interfered with the mock provider settings, causing tests to use the wrong provider.

## Solution

The shared ProcessHarness now:
1. Creates an isolated temp HOME directory for each test process
2. Detects when tests provide their own HOME (like session-commands tests) and doesn't override it
3. Cleans up temp directories on process exit

## Test plan
- [x] All 1970 tests pass locally
- [x] Verified e2e tests run with isolated HOME

🤖 Generated with [Claude Code](https://claude.com/claude-code)