### PR TITLE
feat: add auto-generated conversation labels

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1569,6 +1569,66 @@ ${contextToSummarize}`,
   }
 
   /**
+   * Generate an auto-label for the conversation based on the first exchange.
+   * Uses the secondary provider (if available) to minimize cost.
+   * Returns null if there's not enough context or an error occurs.
+   */
+  async generateAutoLabel(): Promise<string | null> {
+    // Need at least one user message and one assistant response
+    if (this.messages.length < 2) {
+      return null;
+    }
+
+    // Get the first user message
+    const firstUserMsg = this.messages.find(m => m.role === 'user');
+    if (!firstUserMsg) {
+      return null;
+    }
+
+    // Extract text content from the message
+    const userContent = typeof firstUserMsg.content === 'string'
+      ? firstUserMsg.content
+      : firstUserMsg.content
+          .filter(block => block.type === 'text')
+          .map(block => (block as { type: 'text'; text: string }).text)
+          .join(' ');
+
+    // Truncate if too long
+    const truncatedContent = userContent.length > 500
+      ? userContent.slice(0, 500) + '...'
+      : userContent;
+
+    try {
+      const labelProvider = this.getSummaryProvider();
+      const response = await labelProvider.chat([
+        {
+          role: 'user',
+          content: `Generate a very short label (3-5 words max) that describes the topic of this conversation. Reply with ONLY the label, nothing else.
+
+User's request: "${truncatedContent}"
+
+Label:`,
+        },
+      ]);
+
+      // Clean up the response - remove quotes, trim, limit length
+      let label = response.content.trim();
+      label = label.replace(/^["']|["']$/g, ''); // Remove surrounding quotes
+      label = label.replace(/^Label:\s*/i, ''); // Remove "Label:" prefix if present
+
+      // Limit to reasonable length for prompt display
+      if (label.length > 40) {
+        label = label.slice(0, 40).trim();
+      }
+
+      return label || null;
+    } catch (error) {
+      logger.debug(`Failed to generate auto-label: ${error instanceof Error ? error.message : String(error)}`);
+      return null;
+    }
+  }
+
+  /**
    * Set the conversation history (for loading sessions).
    */
   setHistory(messages: Message[]): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5021,6 +5021,20 @@ Begin by analyzing the query and planning your research approach.`;
         }
       }
       autoSaveSession(commandContext, agent);
+
+      // Auto-generate label after first exchange if not set
+      if (!currentLabel && agent.getHistory().length >= 2) {
+        const autoLabel = await agent.generateAutoLabel();
+        if (autoLabel) {
+          currentLabel = autoLabel;
+          updatePrompt(currentPromptMode);
+          if (commandContext.sessionState) {
+            commandContext.sessionState.label = autoLabel;
+          }
+          // Save again to persist the auto-generated label
+          autoSaveSession(commandContext, agent);
+        }
+      }
     } catch (error) {
       spinner.stop();
       logger.error(error instanceof Error ? error.message : String(error), error instanceof Error ? error : undefined);


### PR DESCRIPTION
## Summary

Extends the conversation label feature (#143) to auto-generate labels after the first chat exchange.

## How it works

1. After the first user message + assistant response, if no label is set
2. Sends the first user message to the secondary provider (or main if no secondary)
3. Asks for a 3-5 word topic summary
4. Sets and displays the label automatically

## Benefits

- Users don't need to manually set labels to get the benefit
- Uses secondary/cheaper provider to minimize cost
- Labels help users remember what conversations are about when resuming
- Still allows manual override with `/label <text>`

## Changes

- `src/agent.ts`: Added `generateAutoLabel()` method
- `src/index.ts`: Hook to generate label after first chat exchange

## Test plan
- [x] Build passes
- [x] All 2001 tests pass
- [ ] Manual test: Start new chat, after first response label appears
- [ ] Manual test: `/label custom` overrides auto-label
- [ ] Manual test: Label persists with session save/load

🤖 Generated with [Claude Code](https://claude.com/claude-code)