### PR TITLE
feat: add /label update command to regenerate labels

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -575,7 +575,7 @@ function showHelp(projectInfo: ProjectInfo | null): void {
   console.log(chalk.dim('  /compact           - Summarize old messages to save context'));
   console.log(chalk.dim('  /status            - Show current context usage'));
   console.log(chalk.dim('  /context           - Show detected project context'));
-  console.log(chalk.dim('  /label [text]      - Set/show conversation label'));
+  console.log(chalk.dim('  /label [text|update|clear] - Set/show/regenerate conversation label'));
   console.log(chalk.dim('  /exit              - Exit the assistant'));
 
   console.log(chalk.bold('\nCode Assistance:'));
@@ -4347,6 +4347,25 @@ Begin by analyzing the query and planning your research approach.`;
         currentLabel = null;
         updatePrompt(currentPromptMode);
         console.log(chalk.dim('Label cleared.'));
+      } else if (labelArg === 'update' || labelArg === 'refresh' || labelArg === 'auto') {
+        // Regenerate label from conversation
+        if (agent.getHistory().length < 2) {
+          console.log(chalk.dim('\nNeed at least one exchange to generate a label.'));
+        } else {
+          console.log(chalk.dim('\nGenerating label...'));
+          const newLabel = await agent.generateAutoLabel();
+          if (newLabel) {
+            currentLabel = newLabel;
+            updatePrompt(currentPromptMode);
+            if (commandContext.sessionState) {
+              commandContext.sessionState.label = newLabel;
+            }
+            autoSaveSession(commandContext, agent);
+            console.log(chalk.dim(`Label updated to: ${chalk.cyan(newLabel)}`));
+          } else {
+            console.log(chalk.dim('Could not generate a label.'));
+          }
+        }
       } else {
         // Set the label
         currentLabel = labelArg;


### PR DESCRIPTION
## Summary

Adds the ability to manually regenerate a conversation label on demand.

## New subcommands

- `/label update` - Regenerate label from current conversation
- `/label refresh` - Alias for update
- `/label auto` - Alias for update

## Use case

When a conversation evolves and the original auto-generated label no longer fits, users can run `/label update` to get a fresh label based on the current conversation state.

## Changes

- `src/index.ts`: Added update/refresh/auto subcommands to /label handler, updated help text

## Test plan
- [x] Build passes
- [x] All 2015 tests pass
- [ ] Manual test: `/label update` regenerates label
- [ ] Manual test: Works after conversation has progressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)