### PR TITLE
fix: prevent spinner from interrupting readline prompt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3414,6 +3414,7 @@ Begin by analyzing the query and planning your research approach.`;
     promptUser = (preserveCursor?: boolean) => {
       rl?.prompt(preserveCursor);
       workerStatusUI?.setPromptActive(true);
+      spinner.setPromptActive(true); // Disable spinner while user is typing
     };
     exitApp = () => {
       rl?.close();
@@ -5160,6 +5161,9 @@ Begin by analyzing the query and planning your research approach.`;
   const debugPaste = process.env.DEBUG_PASTE === '1';
   const onLine = (line: string) => {
     if (rlClosed) return;
+
+    // Re-enable spinner now that user has submitted input
+    spinner.setPromptActive(false);
 
     // Check if there's pending paste data (captured by PasteInterceptor)
     const pasteData = consumePendingPaste();

--- a/src/spinner.ts
+++ b/src/spinner.ts
@@ -17,6 +17,7 @@ class SpinnerManager {
   private spinner: Ora | null = null;
   private enabled: boolean = true;
   private streaming: boolean = false;
+  private promptActive: boolean = false;
 
   constructor() {
     // Disable spinners in non-TTY environments (piped output)
@@ -37,7 +38,7 @@ class SpinnerManager {
    * Check if spinners are currently enabled.
    */
   isEnabled(): boolean {
-    return this.enabled && !this.streaming;
+    return this.enabled && !this.streaming && !this.promptActive;
   }
 
   /**
@@ -46,6 +47,17 @@ class SpinnerManager {
   setStreaming(streaming: boolean): void {
     this.streaming = streaming;
     if (streaming && this.spinner) {
+      this.stop();
+    }
+  }
+
+  /**
+   * Mark that the readline prompt is active (disables spinner to avoid interrupting input).
+   * Background indexing and other async operations should not update the spinner while prompt is active.
+   */
+  setPromptActive(active: boolean): void {
+    this.promptActive = active;
+    if (active && this.spinner) {
       this.stop();
     }
   }


### PR DESCRIPTION
## Summary

- Add `setPromptActive()` method to SpinnerManager
- Disable spinner updates while user is at the readline prompt
- Re-enable spinner when user submits input

## Problem

Background indexing operations (RAG, symbol index) update the spinner while the user is typing, which can overwrite their input line and cause visual disruption.

## Solution

Track when the readline prompt is active and prevent spinner updates during that time. The spinner is re-enabled once the user submits their input.

## Test plan

- [x] Build passes
- [x] All 2015 tests pass
- [x] Verified visually that spinner no longer interrupts prompt

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)