### PR TITLE
fix: add React import for Ink UI JSX components

### DIFF
--- a/src/ui/ink/app.tsx
+++ b/src/ui/ink/app.tsx
@@ -1,9 +1,9 @@
 // Copyright 2026 Layne Penney
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Static, Text, useApp, useInput, useStdout } from 'ink';
 import TextInput from 'ink-text-input';
-import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type { ConfirmationResult } from '../../agent.js';
 import type { ReaderResult, ReaderState, WorkerResult, WorkerState } from '../../orchestrate/types.js';

--- a/src/ui/ink/run-ink-ui.tsx
+++ b/src/ui/ink/run-ink-ui.tsx
@@ -1,6 +1,7 @@
 // Copyright 2026 Layne Penney
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import React from 'react';
 import { render } from 'ink';
 
 import { InkApp } from './app.js';


### PR DESCRIPTION
## Summary

Add explicit React imports to Ink UI tsx files to fix "React is not defined" runtime errors.

## Problem

When running `pnpm dev --ui ink`, the app crashed with:
```
ERROR  React is not defined
src/ui/ink/app.tsx:902:3
```

## Solution

Add `import React from 'react'` to both `app.tsx` and `run-ink-ui.tsx`. The tsx runtime needs explicit React imports for JSX to work properly.

## Test plan

- [x] Verified `pnpm dev --ui ink` now starts without error

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)