### PR TITLE
fix: truncate long labels in prompt prefix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3260,8 +3260,13 @@ Begin by analyzing the query and planning your research approach.`;
     }
 
     // Show label as a prefix if set (only in normal mode)
-    const labelPrefix = currentLabel && mode === 'normal'
-      ? chalk.dim(`[${currentLabel}] `)
+    // Truncate long labels to keep prompt compact
+    let displayLabel = currentLabel;
+    if (displayLabel && displayLabel.length > 15) {
+      displayLabel = displayLabel.slice(0, 14) + '…';
+    }
+    const labelPrefix = displayLabel && mode === 'normal'
+      ? chalk.dim(`[${displayLabel}] `)
       : '';
 
     return `\n${labelPrefix}${colorFn(`${baseText}: `)}`;


### PR DESCRIPTION
## Summary

Truncate conversation labels longer than 15 characters in the prompt prefix to keep the prompt compact.

## Problem

Auto-generated labels like "Implementation continuation" (26 chars) create a very long prompt prefix:
```
[Implementation continuation] You: 
```

## Solution

Truncate labels to 15 chars with ellipsis:
```
[Implementatio…] You: 
```

The full label is still stored and shown in session info (`/label` command).

## Test plan

- [x] Build passes
- [x] Verified visually that long labels are truncated

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)