### PR TITLE
fix(orchestrate): graceful IPC disconnect to prevent race condition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3394,7 +3394,10 @@ Begin by analyzing the query and planning your research approach.`;
     console.log(chalk.dim('\nGoodbye!'));
   };
 
-  if (!useInkUi) {
+  // Skip readline creation for non-interactive mode
+  const isNonInteractive = Boolean(options.prompt);
+
+  if (!useInkUi && !isNonInteractive) {
     // Enable bracketed paste mode for better paste detection
     enableBracketedPaste();
 
@@ -3448,7 +3451,7 @@ Begin by analyzing the query and planning your research approach.`;
     rl.on('error', (err) => {
       logger.error(`Readline error: ${err.message}`, err);
     });
-  } else {
+  } else if (useInkUi) {
     exitApp = () => {
       inkController?.requestExit();
     };


### PR DESCRIPTION
## Summary

- Fix race condition where readers/workers report "disconnected unexpectedly" even after successful completion
- Fix non-interactive mode (-P flag) where readline was closing prematurely
- Change `socket.destroy()` to `socket.end()` with proper drain handling
- Add 1-second timeout as safety fallback

## Problem 1: IPC Disconnect Race

The IPC client was using `socket.destroy()` which immediately closes the socket without waiting for pending writes to complete. This caused a race condition:

1. Child agent sends `task_complete` message
2. Child immediately calls `disconnect()` which destroys the socket  
3. Server receives `close` event before processing the completion message
4. Reader/worker marked as "disconnected unexpectedly"

## Problem 2: Non-Interactive Mode Exit

In non-interactive mode (`-P` flag), readline was still being created. When stdin closed (non-TTY mode), readline's close event triggered `handleExit()` before the prompt was processed.

## Solution

### IPC Client
Use `socket.end()` with a drain wait to ensure pending writes complete:

```typescript
async disconnect(): Promise<void> {
  await new Promise<void>((resolve) => {
    const timeout = setTimeout(() => {
      socket.destroy();
      resolve();
    }, 1000);

    socket.once('close', () => {
      clearTimeout(timeout);
      resolve();
    });

    socket.end(); // Graceful close
  });
}
```

### Non-Interactive Mode
Skip readline creation when `-P` flag is used:

```typescript
const isNonInteractive = Boolean(options.prompt);
if (!useInkUi && !isNonInteractive) {
  // Create readline only for interactive mode
}
```

## Test plan

- [x] Build passes
- [x] All 2070 tests pass
- [x] Orchestrate tests pass (14 tests)
- [x] Non-interactive mode works: `codi -P "what is 2+2?"` → "Four"
- [x] Readers spawn and errors are reported properly (not "disconnected unexpectedly")

🤖 Generated with [Claude Code](https://claude.com/claude-code)