### PR TITLE
fix: add debug logging to silenced error handlers

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -461,8 +461,8 @@ ${contextToSummarize}`,
       try {
         const summarizeModel = this.modelMap.router.getSummarizeModel();
         return this.modelMap.registry.getProvider(summarizeModel.name);
-      } catch {
-        // Fall through to secondary/primary
+      } catch (error) {
+        logger.debug(`Model map summarize provider unavailable, using fallback: ${error instanceof Error ? error.message : error}`);
       }
     }
     return this.secondaryProvider ?? this.provider;
@@ -479,8 +479,8 @@ ${contextToSummarize}`,
         if (result.type === 'model') {
           return this.modelMap.registry.getProvider(result.model.name);
         }
-      } catch {
-        // Fall through to primary
+      } catch (error) {
+        logger.debug(`Task routing failed for '${taskType}', using primary: ${error instanceof Error ? error.message : error}`);
       }
     }
     return this.provider;
@@ -497,8 +497,8 @@ ${contextToSummarize}`,
         if (result.type === 'model') {
           return this.modelMap.registry.getProvider(result.model.name);
         }
-      } catch {
-        // Fall through to primary
+      } catch (error) {
+        logger.debug(`Command routing failed for '${commandName}', using primary: ${error instanceof Error ? error.message : error}`);
       }
     }
     return this.provider;
@@ -1286,8 +1286,8 @@ ${contextToSummarize}`,
                 diffPreview = await generateEditDiff(path, oldString, newString, replaceAll);
               }
             }
-          } catch {
-            // If diff generation fails, continue without preview
+          } catch (error) {
+            logger.debug(`Diff generation failed: ${error instanceof Error ? error.message : error}`);
           }
 
           // Get approval suggestions for bash commands (unless dangerous)
@@ -2337,7 +2337,8 @@ Label:`,
 
     try {
       return JSON.parse(readFileSync(filePath, 'utf8'));
-    } catch {
+    } catch (error) {
+      logger.debug(`Failed to load checkpoint ${checkpointId}: ${error instanceof Error ? error.message : error}`);
       return null;
     }
   }
@@ -2369,8 +2370,8 @@ Label:`,
           messageCount: cp.messageCount,
           tokenCount: cp.tokenCount,
         });
-      } catch {
-        // Skip invalid checkpoint files
+      } catch (error) {
+        logger.debug(`Skipping invalid checkpoint file ${file}: ${error instanceof Error ? error.message : error}`);
       }
     }
 
@@ -2529,8 +2530,8 @@ Label:`,
     try {
       this.timeline = JSON.parse(readFileSync(filePath, 'utf8'));
       this.currentBranch = this.timeline.activeBranch;
-    } catch {
-      // Keep default timeline
+    } catch (error) {
+      logger.debug(`Failed to load timeline: ${error instanceof Error ? error.message : error}`);
     }
   }
 
@@ -2618,7 +2619,8 @@ ${contextToSummarize}`,
       );
       this.conversationSummary = summaryResponse.content;
       this.messages = applySelection(this.messages, selection);
-    } catch {
+    } catch (error) {
+      logger.debug(`Summarization failed during compaction: ${error instanceof Error ? error.message : error}`);
       this.messages = applySelection(this.messages, selection);
     }
 

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -8,6 +8,7 @@ import { createTwoFilesPatch, structuredPatch } from 'diff';
 import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
+import { logger } from './logger.js';
 
 /**
  * Represents a diff between two versions of content.
@@ -46,8 +47,8 @@ export async function generateWriteDiff(
   if (!isNewFile) {
     try {
       oldContent = await readFile(resolvedPath, 'utf-8');
-    } catch {
-      // If we can't read the file, treat it as new
+    } catch (error) {
+      logger.debug(`Cannot read file for diff, treating as new: ${error instanceof Error ? error.message : error}`);
     }
   }
 

--- a/src/history.ts
+++ b/src/history.ts
@@ -8,6 +8,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { homedir, tmpdir } from 'os';
+import { logger } from './logger.js';
 
 /** Maximum number of history entries to keep */
 const MAX_HISTORY_SIZE = 50;
@@ -101,7 +102,8 @@ function loadIndex(): HistoryIndex {
   try {
     const content = fs.readFileSync(indexPath, 'utf-8');
     return JSON.parse(content) as HistoryIndex;
-  } catch {
+  } catch (error) {
+    logger.debug(`Failed to load history index: ${error instanceof Error ? error.message : error}`);
     return { entries: [], version: 1 };
   }
 }
@@ -139,8 +141,8 @@ function pruneHistory(index: HistoryIndex): void {
     if (fs.existsSync(backupPath)) {
       try {
         fs.unlinkSync(backupPath);
-      } catch {
-        // Ignore cleanup errors
+      } catch (error) {
+        logger.debug(`Failed to delete backup ${backupPath}: ${error instanceof Error ? error.message : error}`);
       }
     }
   }
@@ -164,8 +166,8 @@ export function recordChange(options: {
   if (fs.existsSync(absolutePath)) {
     try {
       originalContent = fs.readFileSync(absolutePath, 'utf-8');
-    } catch {
-      // If we can't read it, treat as null
+    } catch (error) {
+      logger.debug(`Failed to read original content of ${absolutePath}: ${error instanceof Error ? error.message : error}`);
     }
   }
 
@@ -348,8 +350,8 @@ export function clearHistory(): number {
   if (fs.existsSync(backupsDir)) {
     try {
       fs.rmSync(backupsDir, { recursive: true });
-    } catch {
-      // Ignore errors
+    } catch (error) {
+      logger.debug(`Failed to remove backups directory: ${error instanceof Error ? error.message : error}`);
     }
   }
 

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -13,6 +13,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { logger } from './logger.js';
 
 const CODI_DIR = path.join(os.homedir(), '.codi');
 const PROFILE_PATH = path.join(CODI_DIR, 'profile.yaml');
@@ -163,7 +164,8 @@ export function loadProfile(): UserProfile {
   try {
     const content = fs.readFileSync(PROFILE_PATH, 'utf-8');
     return parseSimpleYaml(content);
-  } catch {
+  } catch (error) {
+    logger.debug(`Failed to load profile: ${error instanceof Error ? error.message : error}`);
     return {};
   }
 }
@@ -307,7 +309,8 @@ export function loadMemories(): MemoryEntry[] {
   try {
     const content = fs.readFileSync(MEMORIES_PATH, 'utf-8');
     return parseMemories(content);
-  } catch {
+  } catch (error) {
+    logger.debug(`Failed to load memories: ${error instanceof Error ? error.message : error}`);
     return [];
   }
 }
@@ -495,7 +498,8 @@ export function getSessionNotes(): string[] {
       .map(line => line.trim())
       .filter(line => line.startsWith('-'))
       .map(line => line.slice(1).trim());
-  } catch {
+  } catch (error) {
+    logger.debug(`Failed to load session notes: ${error instanceof Error ? error.message : error}`);
     return [];
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import type { Message, ContentBlock } from './types.js';
+import { logger } from './logger.js';
 
 const SESSIONS_DIR = path.join(os.homedir(), '.codi', 'sessions');
 
@@ -157,7 +158,8 @@ export function loadSession(name: string): Session | null {
     }
 
     return session;
-  } catch {
+  } catch (error) {
+    logger.debug(`Failed to load session '${name}': ${error instanceof Error ? error.message : error}`);
     return null;
   }
 }

--- a/src/spinner.ts
+++ b/src/spinner.ts
@@ -9,6 +9,7 @@
 
 import ora, { type Ora } from 'ora';
 import chalk from 'chalk';
+import { logger } from './logger.js';
 
 /**
  * Manages a single spinner instance with TTY detection and state management.
@@ -80,8 +81,8 @@ class SpinnerManager {
         spinner: 'dots',
         discardStdin: false, // Don't interfere with readline's stdin handling
       }).start();
-    } catch {
-      // Silently ignore spinner errors - they shouldn't break the app
+    } catch (error) {
+      logger.debug(`Spinner start failed: ${error instanceof Error ? error.message : error}`);
       this.spinner = null;
     }
   }
@@ -144,7 +145,8 @@ class SpinnerManager {
         this.spinner.stop();
         this.spinner = null;
       }
-    } catch {
+    } catch (error) {
+      logger.debug(`Spinner stop failed: ${error instanceof Error ? error.message : error}`);
       this.spinner = null;
     }
   }

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { homedir } from 'os';
 import type { TokenUsage } from './types.js';
+import { logger } from './logger.js';
 
 /** Directory where usage data is stored */
 const USAGE_DIR = path.join(homedir(), '.codi');
@@ -152,7 +153,8 @@ function loadUsageData(): UsageData {
   try {
     const content = fs.readFileSync(USAGE_FILE, 'utf-8');
     return JSON.parse(content) as UsageData;
-  } catch {
+  } catch (error) {
+    logger.debug(`Failed to load usage data: ${error instanceof Error ? error.message : error}`);
     return { records: [], version: 1 };
   }
 }


### PR DESCRIPTION
## Summary

Replace empty catch blocks with `logger.debug()` calls to improve debugging while preserving the original fallback behavior.

Closes #126

## Problem

Multiple locations used empty catch blocks that silently discarded errors, making debugging impossible:
- `src/memory.ts` - profile/memories loading
- `src/session.ts` - session loading  
- `src/history.ts` - history index loading

## Solution

Add debug logging using the existing `logger.debug()` method. Logs only appear when running with `--debug` flag, so normal behavior is unchanged.

## Files Changed

| File | What's Logged |
|------|--------------|
| `src/memory.ts` | Profile, memories, session notes loading failures |
| `src/session.ts` | Session loading failures |
| `src/history.ts` | History index loading and backup cleanup |
| `src/usage.ts` | Usage data loading failures |
| `src/agent.ts` | Model routing, diff generation, checkpoints, timeline |
| `src/diff.ts` | File reading for diff generation |
| `src/spinner.ts` | Spinner start/stop errors |

## Example

Before:
```typescript
} catch {
  return null;
}
```

After:
```typescript
} catch (error) {
  logger.debug(`Failed to load session '${name}': ${error instanceof Error ? error.message : error}`);
  return null;
}
```

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (2151 tests)
- [x] Debug messages only appear with `--debug` flag
- [x] Normal behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)