### PR TITLE
fix: convert memory.ts to async file operations (#124)

### DIFF
--- a/src/commands/memory-commands.ts
+++ b/src/commands/memory-commands.ts
@@ -130,7 +130,7 @@ Examples:
       content = categoryMatch[2];
     }
 
-    const entry = addMemory(content, category, 'user');
+    const entry = await addMemory(content, category, 'user');
 
     return `__MEMORY_ADDED__|${entry.content}|${entry.category || ''}|${entry.timestamp}`;
   },
@@ -157,11 +157,11 @@ Examples:
     }
 
     if (pattern.toLowerCase() === 'all') {
-      const count = clearMemories();
+      const count = await clearMemories();
       return `__MEMORY_CLEARED__|${count}`;
     }
 
-    const removed = removeMemories(pattern);
+    const removed = await removeMemories(pattern);
 
     if (removed === 0) {
       return `__MEMORY_NOTFOUND__|${pattern}`;
@@ -189,7 +189,7 @@ Examples:
     const query = args.trim();
 
     if (query.toLowerCase() === 'consolidate') {
-      const count = consolidateSessionNotes();
+      const count = await consolidateSessionNotes();
       if (count === 0) {
         return '__MEMORY_CONSOLIDATED__|0';
       }
@@ -198,9 +198,9 @@ Examples:
 
     let memories: MemoryEntry[];
     if (query) {
-      memories = searchMemories(query);
+      memories = await searchMemories(query);
     } else {
-      memories = loadMemories();
+      memories = await loadMemories();
     }
 
     const paths = getMemoryPaths();
@@ -238,11 +238,11 @@ Examples:
     if (parts[0] === 'set' && parts.length >= 3) {
       const key = parts[1];
       const value = parts.slice(2).join(' ');
-      const profile = updateProfile(key, value);
+      const profile = await updateProfile(key, value);
       return `__PROFILE_UPDATED__|${key}|${value}|${JSON.stringify(profile)}`;
     }
 
-    const profile = loadProfile();
+    const profile = await loadProfile();
     const paths = getMemoryPaths();
     return `__PROFILE_SHOW__|${JSON.stringify(profile)}|${paths.profile}`;
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2960,7 +2960,7 @@ Begin by analyzing the query and planning your research approach.`;
   }
 
   // Inject memory context (profile + memories)
-  const memoryContext = generateMemoryContext(process.cwd());
+  const memoryContext = await generateMemoryContext(process.cwd());
   if (memoryContext) {
     systemPrompt += `\n\n${memoryContext}`;
   }
@@ -3148,7 +3148,7 @@ Begin by analyzing the query and planning your research approach.`;
     defaultModel: provider.getModel(),
 
     // Provide background context for spawned agents
-    contextProvider: (_childId, _task) => {
+    contextProvider: async (_childId, _task) => {
       const parts: string[] = [];
 
       // Add project info
@@ -3169,7 +3169,7 @@ Begin by analyzing the query and planning your research approach.`;
       }
 
       // Add memory context (profile + memories)
-      const memoryCtx = generateMemoryContext(process.cwd());
+      const memoryCtx = await generateMemoryContext(process.cwd());
       if (memoryCtx) {
         parts.push('## User Context');
         parts.push(memoryCtx.slice(0, 2000)); // Limit size

--- a/tests/memory-commands.test.ts
+++ b/tests/memory-commands.test.ts
@@ -13,38 +13,38 @@ import type { CommandContext } from '../src/commands/index.js';
 
 // Mock the memory module
 vi.mock('../src/memory.js', () => ({
-  loadProfile: vi.fn().mockReturnValue({
+  loadProfile: vi.fn().mockResolvedValue({
     name: 'TestUser',
     preferences: { language: 'TypeScript', style: 'functional' },
     expertise: ['React', 'Node.js'],
     avoid: ['jQuery'],
   }),
-  updateProfile: vi.fn().mockReturnValue({
+  updateProfile: vi.fn().mockResolvedValue({
     name: 'UpdatedUser',
     preferences: { language: 'TypeScript' },
   }),
-  loadMemories: vi.fn().mockReturnValue([
+  loadMemories: vi.fn().mockResolvedValue([
     { content: 'Prefers dark mode', category: 'preferences', timestamp: '2024-01-15T10:00:00.000Z', source: 'user' },
     { content: 'Uses pnpm', category: 'project', timestamp: '2024-01-15T11:00:00.000Z', source: 'user' },
     { content: 'No category memory', timestamp: '2024-01-15T12:00:00.000Z', source: 'user' },
   ]),
-  addMemory: vi.fn().mockReturnValue({
+  addMemory: vi.fn().mockResolvedValue({
     content: 'New memory content',
     category: 'test',
     timestamp: '2024-01-15T13:00:00.000Z',
     source: 'user',
   }),
-  removeMemories: vi.fn().mockReturnValue(2),
-  searchMemories: vi.fn().mockReturnValue([
+  removeMemories: vi.fn().mockResolvedValue(2),
+  searchMemories: vi.fn().mockResolvedValue([
     { content: 'Uses pnpm', category: 'project', timestamp: '2024-01-15T11:00:00.000Z', source: 'user' },
   ]),
-  clearMemories: vi.fn().mockReturnValue(3),
+  clearMemories: vi.fn().mockResolvedValue(3),
   getMemoryPaths: vi.fn().mockReturnValue({
     profile: '/home/user/.codi/profile.yaml',
     memories: '/home/user/.codi/memories.md',
     sessionNotes: '/home/user/.codi/session-notes.md',
   }),
-  consolidateSessionNotes: vi.fn().mockReturnValue(5),
+  consolidateSessionNotes: vi.fn().mockResolvedValue(5),
 }));
 
 // Mock the commands/index module
@@ -112,7 +112,7 @@ describe('Memory Commands', () => {
     });
 
     it('adds memory with category prefix', async () => {
-      mockAddMemory.mockReturnValueOnce({
+      mockAddMemory.mockResolvedValueOnce({
         content: 'Uses pnpm',
         category: 'project',
         timestamp: '2024-01-15T13:00:00.000Z',
@@ -156,7 +156,7 @@ describe('Memory Commands', () => {
     });
 
     it('handles no matches found', async () => {
-      mockRemoveMemories.mockReturnValueOnce(0);
+      mockRemoveMemories.mockResolvedValueOnce(0);
       const result = await forgetCommand.execute('NonexistentPattern', createContext());
 
       expect(result).toContain('__MEMORY_NOTFOUND__');
@@ -202,7 +202,7 @@ describe('Memory Commands', () => {
     });
 
     it('handles zero consolidations', async () => {
-      mockConsolidateSessionNotes.mockReturnValueOnce(0);
+      mockConsolidateSessionNotes.mockResolvedValueOnce(0);
       const result = await memoriesCommand.execute('consolidate', createContext());
 
       expect(result).toContain('__MEMORY_CONSOLIDATED__');

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -164,7 +164,7 @@ describe('Memory Module Integration', () => {
     }
 
     const memory = await import('../src/memory.js');
-    const profile = memory.loadProfile();
+    const profile = await memory.loadProfile();
     expect(profile).toEqual({});
   });
 
@@ -176,8 +176,8 @@ describe('Memory Module Integration', () => {
 
     const memory = await import('../src/memory.js');
 
-    memory.addMemory('Test memory for integration test');
-    const memories = memory.loadMemories();
+    await memory.addMemory('Test memory for integration test');
+    const memories = await memory.loadMemories();
 
     expect(memories.length).toBeGreaterThan(0);
     expect(memories.some(m => m.content === 'Test memory for integration test')).toBe(true);
@@ -186,22 +186,22 @@ describe('Memory Module Integration', () => {
   it('should clear memories', async () => {
     const memory = await import('../src/memory.js');
 
-    memory.addMemory('Memory to clear');
-    memory.clearMemories();
+    await memory.addMemory('Memory to clear');
+    await memory.clearMemories();
 
-    const memories = memory.loadMemories();
+    const memories = await memory.loadMemories();
     expect(memories.length).toBe(0);
   });
 
   it('should save and load profile', async () => {
     const memory = await import('../src/memory.js');
 
-    memory.saveProfile({
+    await memory.saveProfile({
       name: 'Integration Test User',
       preferences: { language: 'TypeScript' },
     });
 
-    const profile = memory.loadProfile();
+    const profile = await memory.loadProfile();
     expect(profile.name).toBe('Integration Test User');
     expect(profile.preferences?.language).toBe('TypeScript');
   });
@@ -210,15 +210,15 @@ describe('Memory Module Integration', () => {
     const memory = await import('../src/memory.js');
 
     // Clear and set up test data
-    memory.clearMemories();
+    await memory.clearMemories();
     if (fs.existsSync(PROFILE_PATH)) {
       fs.unlinkSync(PROFILE_PATH);
     }
 
-    memory.saveProfile({ name: 'Context Test User' });
-    memory.addMemory('Important context fact');
+    await memory.saveProfile({ name: 'Context Test User' });
+    await memory.addMemory('Important context fact');
 
-    const context = memory.generateMemoryContext();
+    const context = await memory.generateMemoryContext();
     expect(context).not.toBeNull();
     expect(context).toContain('Context Test User');
     expect(context).toContain('Important context fact');


### PR DESCRIPTION
## Summary

Converts synchronous file operations in `src/memory.ts` to async for improved performance and non-blocking I/O. This is part of addressing issue #124.

### Changes

**memory.ts** - All file I/O now uses `fs/promises`:
- `loadProfile()` - async with `readFile`
- `saveProfile()` - async with `writeFile`
- `updateProfile()` - async
- `loadMemories()` - async with `readFile`
- `saveMemories()` - async with `writeFile`
- `addMemory()`, `removeMemories()`, `searchMemories()`, `getMemoriesByCategory()`, `clearMemories()` - async
- `generateMemoryContext()` - async (called during startup)
- `addSessionNote()` - async with `appendFile`
- `getSessionNotes()`, `consolidateSessionNotes()`, `hasMemoryContext()` - async

**Updated callers**:
- `src/commands/memory-commands.ts` - await all memory function calls
- `src/index.ts` - await `generateMemoryContext` in `main()` and `contextProvider`
- `src/orchestrate/commander.ts` - `ContextProviderCallback` type now supports async, `handleWorkerConnected` is async

**Updated tests**:
- `tests/memory-commands.test.ts` - use `mockResolvedValue` instead of `mockReturnValue`
- `tests/memory.test.ts` - await async memory functions in integration tests

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (2151 tests)
- [x] Memory commands work correctly (`/remember`, `/forget`, `/memories`, `/profile`)
- [x] Memory context is properly injected into system prompt at startup

## Notes

This PR focuses on `memory.ts` as it contains the most impactful conversions (called during startup). Converting `session.ts` and `history.ts` would require updating 30+ call sites and may be done in follow-up PRs if performance issues are identified.

Closes #124 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)