### PR TITLE
fix: consolidate duplicate MODEL_PRICING constants (#129)

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -6,32 +6,7 @@
  * Used as fallback when API model listing is unavailable.
  */
 import type { ModelInfo } from './providers/base.js';
-
-/**
- * Pricing per 1M tokens (in USD) for various models.
- * Keep in sync with usage.ts MODEL_PRICING.
- */
-const MODEL_PRICING: Record<string, { input: number; output: number }> = {
-  // Anthropic Claude models
-  'claude-opus-4-5-20251101': { input: 15.0, output: 75.0 },
-  'claude-opus-4-20250514': { input: 15.0, output: 75.0 },
-  'claude-sonnet-4-20250514': { input: 3.0, output: 15.0 },
-  'claude-3-5-sonnet-20241022': { input: 3.0, output: 15.0 },
-  'claude-3-5-haiku-20241022': { input: 0.80, output: 4.0 },
-  'claude-3-opus-20240229': { input: 15.0, output: 75.0 },
-  'claude-3-sonnet-20240229': { input: 3.0, output: 15.0 },
-  'claude-3-haiku-20240307': { input: 0.25, output: 1.25 },
-
-  // OpenAI GPT models
-  'gpt-4o': { input: 2.5, output: 10.0 },
-  'gpt-4o-mini': { input: 0.15, output: 0.6 },
-  'gpt-4-turbo': { input: 10.0, output: 30.0 },
-  'gpt-4': { input: 30.0, output: 60.0 },
-  'gpt-3.5-turbo': { input: 0.5, output: 1.5 },
-  'o1': { input: 15.0, output: 60.0 },
-  'o1-mini': { input: 3.0, output: 12.0 },
-  'o3-mini': { input: 1.1, output: 4.4 },
-};
+import { MODEL_PRICING, getModelPricing } from './pricing.js';
 
 /**
  * Static list of known models with their capabilities.
@@ -194,24 +169,8 @@ export function getStaticModels(provider?: string): ModelInfo[] {
   return STATIC_MODELS;
 }
 
-/**
- * Get pricing for a specific model.
- */
-export function getModelPricing(modelId: string): { input: number; output: number } | undefined {
-  // Try exact match first
-  if (MODEL_PRICING[modelId]) {
-    return MODEL_PRICING[modelId];
-  }
-
-  // Try prefix match
-  for (const [key, pricing] of Object.entries(MODEL_PRICING)) {
-    if (modelId.startsWith(key) || key.startsWith(modelId)) {
-      return pricing;
-    }
-  }
-
-  return undefined;
-}
+// Re-export getModelPricing from shared pricing module
+export { getModelPricing } from './pricing.js';
 
 /**
  * Get context window size for a specific model.

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,0 +1,60 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Model pricing constants - single source of truth.
+ *
+ * Pricing per 1M tokens (in USD) for various models.
+ * Used by both models.ts and usage.ts.
+ */
+
+export interface ModelPricing {
+  input: number;
+  output: number;
+}
+
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  // Anthropic Claude models
+  'claude-opus-4-5-20251101': { input: 15.0, output: 75.0 },
+  'claude-opus-4-20250514': { input: 15.0, output: 75.0 },
+  'claude-sonnet-4-20250514': { input: 3.0, output: 15.0 },
+  'claude-3-5-sonnet-20241022': { input: 3.0, output: 15.0 },
+  'claude-3-5-haiku-20241022': { input: 0.80, output: 4.0 },
+  'claude-3-opus-20240229': { input: 15.0, output: 75.0 },
+  'claude-3-sonnet-20240229': { input: 3.0, output: 15.0 },
+  'claude-3-haiku-20240307': { input: 0.25, output: 1.25 },
+
+  // OpenAI GPT models
+  'gpt-4o': { input: 2.5, output: 10.0 },
+  'gpt-4o-mini': { input: 0.15, output: 0.6 },
+  'gpt-4-turbo': { input: 10.0, output: 30.0 },
+  'gpt-4': { input: 30.0, output: 60.0 },
+  'gpt-3.5-turbo': { input: 0.5, output: 1.5 },
+  'o1': { input: 15.0, output: 60.0 },
+  'o1-mini': { input: 3.0, output: 12.0 },
+  'o3-mini': { input: 1.1, output: 4.4 },
+
+  // Default for unknown models (free/local)
+  'default': { input: 0, output: 0 },
+};
+
+/**
+ * Get pricing for a model with prefix matching fallback.
+ * Returns default pricing if model is not found.
+ */
+export function getModelPricing(model: string): ModelPricing {
+  // Try exact match first
+  if (MODEL_PRICING[model]) {
+    return MODEL_PRICING[model];
+  }
+
+  // Try prefix match (e.g., "claude-3-sonnet" matches "claude-3-sonnet-20240229")
+  for (const [key, pricing] of Object.entries(MODEL_PRICING)) {
+    if (key !== 'default' && (model.startsWith(key) || key.startsWith(model))) {
+      return pricing;
+    }
+  }
+
+  // Default (free/local models)
+  return MODEL_PRICING['default'];
+}

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -9,39 +9,11 @@ import * as path from 'path';
 import { homedir } from 'os';
 import type { TokenUsage } from './types.js';
 import { logger } from './logger.js';
+import { getModelPricing } from './pricing.js';
 
 /** Directory where usage data is stored */
 const USAGE_DIR = path.join(homedir(), '.codi');
 const USAGE_FILE = path.join(USAGE_DIR, 'usage.json');
-
-/**
- * Pricing per 1M tokens (in USD) for various models.
- * Prices as of early 2025.
- */
-const MODEL_PRICING: Record<string, { input: number; output: number }> = {
-  // Anthropic Claude models
-  'claude-opus-4-5-20251101': { input: 15.0, output: 75.0 },
-  'claude-opus-4-20250514': { input: 15.0, output: 75.0 },
-  'claude-sonnet-4-20250514': { input: 3.0, output: 15.0 },
-  'claude-3-5-sonnet-20241022': { input: 3.0, output: 15.0 },
-  'claude-3-5-haiku-20241022': { input: 0.80, output: 4.0 },
-  'claude-3-opus-20240229': { input: 15.0, output: 75.0 },
-  'claude-3-sonnet-20240229': { input: 3.0, output: 15.0 },
-  'claude-3-haiku-20240307': { input: 0.25, output: 1.25 },
-
-  // OpenAI GPT models
-  'gpt-4o': { input: 2.5, output: 10.0 },
-  'gpt-4o-mini': { input: 0.15, output: 0.6 },
-  'gpt-4-turbo': { input: 10.0, output: 30.0 },
-  'gpt-4': { input: 30.0, output: 60.0 },
-  'gpt-3.5-turbo': { input: 0.5, output: 1.5 },
-  'o1': { input: 15.0, output: 60.0 },
-  'o1-mini': { input: 3.0, output: 12.0 },
-  'o3-mini': { input: 1.1, output: 4.4 },
-
-  // Default for unknown models (free/local)
-  'default': { input: 0, output: 0 },
-};
 
 /**
  * A single usage record.
@@ -165,26 +137,6 @@ function loadUsageData(): UsageData {
 function saveUsageData(data: UsageData): void {
   ensureUsageDir();
   fs.writeFileSync(USAGE_FILE, JSON.stringify(data, null, 2));
-}
-
-/**
- * Get pricing for a model.
- */
-function getModelPricing(model: string): { input: number; output: number } {
-  // Try exact match first
-  if (MODEL_PRICING[model]) {
-    return MODEL_PRICING[model];
-  }
-
-  // Try prefix match (e.g., "claude-3-sonnet" matches "claude-3-sonnet-20240229")
-  for (const [key, pricing] of Object.entries(MODEL_PRICING)) {
-    if (model.startsWith(key) || key.startsWith(model)) {
-      return pricing;
-    }
-  }
-
-  // Default (free/local models)
-  return MODEL_PRICING['default'];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Create shared `src/pricing.ts` module with MODEL_PRICING constant
- Update `src/models.ts` to import and re-export from pricing.ts
- Update `src/usage.ts` to import getModelPricing from pricing.ts
- Add ModelPricing interface for type safety

This eliminates the maintenance burden of keeping two identical pricing tables in sync. Previously, pricing updates had to be made in both `src/models.ts` and `src/usage.ts`, risking inconsistencies.

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All 2151 tests pass (`pnpm test`)
- [x] Verify pricing lookups work correctly via usage tracking

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)