### PR TITLE
chore: configure npm publishing as codi-ai

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "codi",
+  "name": "codi-ai",
   "version": "0.17.0",
   "description": "Your AI coding wingman - a hybrid assistant supporting Claude, OpenAI, and local models",
   "author": "Layne Penney",
@@ -38,7 +38,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "docs": "typedoc",
-    "docs:watch": "typedoc --watch"
+    "docs:watch": "typedoc --watch",
+    "prepublishOnly": "pnpm build && pnpm test"
   },
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary

Configure package for npm publishing:
- Rename package to `codi-ai` (the name `codi` was already taken on npm)
- Add `prepublishOnly` script to run build and tests before publish

## Installation

After publishing, users will install with:
```bash
npm install -g codi-ai
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)