### PR TITLE
ci: add GitHub Actions workflow for npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for npm trusted publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow to automatically publish to npm when a GitHub release is created.

Uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/) with OIDC authentication - no npm tokens needed.

## Workflow triggers

- Runs on `release: published` events
- Builds, tests, then publishes with provenance

## Setup required

Configure trusted publisher on npmjs.com:
1. Go to https://www.npmjs.com/package/codi-ai/access
2. Add GitHub Actions as trusted publisher:
   - Owner: `laynepenney`
   - Repository: `codi`
   - Workflow: `publish.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)