### PR TITLE
fix: update npm version for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,5 +32,8 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish to npm
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

Fix npm trusted publishing by installing npm v11.5.1+ before publish.

Node 22 ships with npm v10, but [trusted publishing requires npm v11.5.1+](https://medium.com/@kenricktan11/npm-trusted-publishers-the-weird-404-error-and-the-node-js-24-fix-a9f1d717a5dd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)