### PR TITLE
chore: bump version to 0.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codi-ai",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Your AI coding wingman - a hybrid assistant supporting Claude, OpenAI, and local models",
   "author": "Layne Penney",
   "license": "AGPL-3.0-or-later",

--- a/src/version.ts
+++ b/src/version.ts
@@ -10,4 +10,4 @@
  * - MINOR: New features, significant refactoring, non-breaking changes
  * - PATCH: Bug fixes, minor improvements
  */
-export const VERSION = '0.18.0';
+export const VERSION = '0.18.1';


### PR DESCRIPTION
## Summary
- Bump version to 0.18.1 to re-trigger npm publish workflow

The v0.18.0 tag is locked due to the previous release attempt. This version bump allows us to create a fresh release with the fixed workflow (now includes `npm install -g npm@latest` for trusted publishing support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)