### PR TITLE
fix(test): correct completions test expectations

### DIFF
--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -327,9 +327,16 @@ describe('Command Completions', () => {
       expect(result).toBeNull();
     });
 
-    it('returns completed command for single match', () => {
+    it('returns common prefix when multiple matches exist', () => {
+      // /br matches both /br (alias) and /branch (command)
       const result = completeLine('/br');
-      expect(result).toBe('/branch ');
+      expect(result).toBe('/br');
+    });
+
+    it('returns completed command for truly single match', () => {
+      // /bran only matches /branch (not /br alias)
+      const result = completeLine('/bran');
+      expect(result).toBe('/branch');
     });
 
     it('returns common prefix for multiple matches', () => {
@@ -373,8 +380,9 @@ describe('Command Completions', () => {
     });
 
     it('returns common prefix for multiple strings', () => {
+      // All three start with '/co' (commit, compact, config)
       const result = getCommonPrefix(['/commit', '/compact', '/config']);
-      expect(result).toBe('/c');
+      expect(result).toBe('/co');
     });
 
     it('returns empty when no common prefix', () => {


### PR DESCRIPTION
## Summary
Fix 2 failing tests in `tests/completions.test.ts`:

1. **`completeLine('/br')` test**: Changed expectation from `/branch ` to `/br`
   - `/br` matches both the `/br` alias AND `/branch` command
   - With multiple matches, `completeLine` returns the common prefix, not the full completion
   - Added new test for truly single match using `/bran` → `/branch`

2. **`getCommonPrefix` test**: Changed expected value from `/c` to `/co`
   - The common prefix of `/commit`, `/compact`, `/config` is `/co` (all start with `co`)
   - The old expectation was mathematically incorrect

## Test plan
- [x] All 2085 tests pass (`pnpm test`)
- [x] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)