### PR TITLE
feat(ui): add turn stats display with running tool count

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -180,6 +180,34 @@ export interface ProviderConfig {
   cleanHallucinatedTraces?: boolean;
 }
 
+/** Details of a single tool call within a turn */
+export interface TurnToolCall {
+  /** Tool name */
+  name: string;
+  /** Duration of tool execution in milliseconds */
+  durationMs: number;
+  /** Whether the tool call resulted in an error */
+  isError: boolean;
+}
+
+/** Statistics for a single conversation turn */
+export interface TurnStats {
+  /** Number of tool calls in this turn */
+  toolCallCount: number;
+  /** Total input tokens used in this turn */
+  inputTokens: number;
+  /** Total output tokens used in this turn */
+  outputTokens: number;
+  /** Total tokens (input + output) */
+  totalTokens: number;
+  /** Estimated cost in USD */
+  cost: number;
+  /** Duration of the turn in milliseconds */
+  durationMs: number;
+  /** Details of each tool call */
+  toolCalls: TurnToolCall[];
+}
+
 /**
  * Interface for AI model providers.
  * This interface defines the contract that all providers must implement.

--- a/src/ui/ink/controller.ts
+++ b/src/ui/ink/controller.ts
@@ -7,6 +7,7 @@ import type { ToolConfirmation, ConfirmationResult } from '../../agent.js';
 import type { WorkerState, WorkerResult, ReaderState, ReaderResult } from '../../orchestrate/types.js';
 import type { LogMessage } from '../../orchestrate/ipc/protocol.js';
 import type { SessionInfo } from '../../session.js';
+import type { TurnStats } from '../../types.js';
 
 export type UiMessageKind = 'user' | 'assistant' | 'system' | 'worker';
 
@@ -40,6 +41,11 @@ export interface UiStatus {
   model?: string;
   activity?: string | null;
   activityDetail?: string | null;
+  /** Running turn progress - tool call count and tokens */
+  turnProgress?: {
+    toolCallCount: number;
+    totalTokens: number;
+  } | null;
 }
 
 export interface UiConfirmationRequest {
@@ -300,6 +306,10 @@ export class InkUiController extends EventEmitter {
   getActiveSessionSelection(): UiSessionSelectionRequest | null {
     return this.sessionSelection?.request ?? null;
   }
+
+  completeTurn(stats: TurnStats): void {
+    this.emit('turnComplete', stats);
+  }
 }
 
 export interface InkUiControllerEvents {
@@ -315,6 +325,7 @@ export interface InkUiControllerEvents {
   status: (status: UiStatus) => void;
   confirmation: (request: UiConfirmationRequest | null) => void;
   sessionSelection: (request: UiSessionSelectionRequest | null) => void;
+  turnComplete: (stats: TurnStats) => void;
   exit: () => void;
 }
 


### PR DESCRIPTION
## Summary

- Add real-time tool usage tracking and display in Ink UI
- Show running tool count in Activity panel: `Agent: Thinking (5 tools)`
- Add turn summary after completion: `Done (N tool uses · Xk tokens)`

## Changes

- **src/types.ts**: Add `TurnStats` and `TurnToolCall` interfaces
- **src/agent.ts**: Add `onTurnComplete` callback, track tool calls and tokens during turn
- **src/ui/ink/controller.ts**: Add `completeTurn()` method and `turnProgress` to status
- **src/ui/ink/app.tsx**: Display tool count in Activity panel and turn summary
- **src/index.ts**: Wire up callbacks, track running counts

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Tests pass (2085 passed, pre-existing failures in unrelated tests)
- [x] Manual test: `pnpm dev --ui ink` - tool count visible during execution
- [x] Verified count increments as tools run
- [x] Verified summary appears after turn completes

## Related

- #217 - Future enhancement for compact tool display with Ctrl+O expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)