### PR TITLE
fix(test): resolve image-commands and config-commands test timeouts

### DIFF
--- a/CODI.md
+++ b/CODI.md
@@ -151,6 +151,13 @@ gh release create vX.Y.Z --title "vX.Y.Z: Title" --notes "Release notes"
 
 **IMPORTANT: Never merge a PR without reviewing it first.** Always review your own PRs before merging. This creates a traceable review history and catches mistakes before they reach main.
 
+**CRITICAL: Never merge a PR until ALL checks pass.** This includes:
+- All tests must pass (`pnpm test` with zero failures)
+- Build must succeed (`pnpm build`)
+- Any CI/CD checks must be green
+
+If tests are failing, fix them before merging - even if the failures appear unrelated to your changes.
+
 **For AI agents (Claude, Codi, etc.):** Do NOT immediately merge after creating a PR. Always:
 1. Create the PR
 2. Run `pnpm build && pnpm test` to verify nothing is broken

--- a/tests/config-commands.test.ts
+++ b/tests/config-commands.test.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect } from 'vitest';
+import { configCommand } from '../src/commands/config-commands.js';
+
+describe('config-commands', () => {
+  describe('metadata', () => {
+    it('should have correct name', () => {
+      expect(configCommand.name).toBe('config');
+    });
+
+    it('should have description', () => {
+      expect(configCommand.description).toBeDefined();
+      expect(typeof configCommand.description).toBe('string');
+    });
+
+    it('should have usage string', () => {
+      expect(configCommand.usage).toBeDefined();
+      expect(typeof configCommand.usage).toBe('string');
+    });
+
+    it('should have execute function', () => {
+      expect(typeof configCommand.execute).toBe('function');
+    });
+  });
+
+  describe('execute', () => {
+    it('should return a string for empty args', async () => {
+      const result = await configCommand.execute('', {} as any);
+      expect(typeof result).toBe('string');
+      // Result is a control string like __CONFIG_SHOW__ or __CONFIG_NOT_FOUND__
+      expect(result?.toLowerCase()).toContain('config');
+    });
+
+    it('should return a string for init subcommand', async () => {
+      const result = await configCommand.execute('init', {} as any);
+      expect(typeof result).toBe('string');
+    });
+
+    it('should return a string for example subcommand', async () => {
+      const result = await configCommand.execute('example', {} as any);
+      expect(typeof result).toBe('string');
+    });
+
+    it('should return a string for invalid subcommand', async () => {
+      const result = await configCommand.execute('invalid', {} as any);
+      expect(typeof result).toBe('string');
+    });
+  });
+});

--- a/tests/image-commands.test.ts
+++ b/tests/image-commands.test.ts
@@ -1,0 +1,87 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { pickImageCommand } from '../src/commands/image-commands.js';
+
+// Mock child_process to prevent spawning fzf
+vi.mock('child_process', () => ({
+  exec: vi.fn((_cmd, callback) => {
+    // Simulate fzf not being available
+    callback(new Error('not found'), '', '');
+  }),
+  spawn: vi.fn(() => ({
+    stdin: { write: vi.fn(), end: vi.fn() },
+    stdout: { on: vi.fn() },
+    on: vi.fn((event, handler) => {
+      if (event === 'close') {
+        // Simulate user cancellation (no selection)
+        handler(1);
+      }
+    }),
+  })),
+}));
+
+// Mock readline to prevent interactive prompts
+vi.mock('readline', () => ({
+  createInterface: vi.fn(() => ({
+    question: vi.fn((_prompt, callback) => {
+      // Simulate empty input (user pressed enter without typing)
+      callback('');
+    }),
+    close: vi.fn(),
+  })),
+}));
+
+describe('image-commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('metadata', () => {
+    it('should have correct name', () => {
+      expect(pickImageCommand.name).toBe('pick-image');
+    });
+
+    it('should have aliases', () => {
+      expect(pickImageCommand.aliases).toBeDefined();
+      expect(Array.isArray(pickImageCommand.aliases)).toBe(true);
+      expect(pickImageCommand.aliases).toContain('pi');
+    });
+
+    it('should have description', () => {
+      expect(pickImageCommand.description).toBeDefined();
+      expect(typeof pickImageCommand.description).toBe('string');
+      expect(pickImageCommand.description).toContain('fzf');
+    });
+
+    it('should have usage string', () => {
+      expect(pickImageCommand.usage).toBeDefined();
+      expect(typeof pickImageCommand.usage).toBe('string');
+      expect(pickImageCommand.usage).toContain('/pick-image');
+    });
+
+    it('should have execute function', () => {
+      expect(typeof pickImageCommand.execute).toBe('function');
+    });
+  });
+
+  describe('execute', () => {
+    it('should return helpful message when no image is selected', async () => {
+      const result = await pickImageCommand.execute('', {} as any);
+      expect(typeof result).toBe('string');
+      expect(result).toContain('No image selected');
+    });
+
+    it('should return helpful message with question context when no image selected', async () => {
+      const result = await pickImageCommand.execute('analyze the colors', {} as any);
+      expect(typeof result).toBe('string');
+      expect(result).toContain('No image selected');
+    });
+
+    it('should suggest providing path directly in fallback message', async () => {
+      const result = await pickImageCommand.execute('', {} as any);
+      expect(result).toContain('provide a path directly');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Mock `child_process` and `readline` in image-commands tests to prevent interactive prompts that cause 10-second timeouts
- Fix case-sensitivity in config-commands test (`__CONFIG_SHOW__` uses uppercase)
- Add explicit rule to CLAUDE.md: never merge a PR until all checks pass

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (all 2191 tests)
- [x] Previously failing tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)