### PR TITLE
feat(codi-rs): Phase 4 Symbol Index - tree-sitter based code navigation

### DIFF
--- a/codi-rs/Cargo.toml
+++ b/codi-rs/Cargo.toml
@@ -79,6 +79,17 @@ globset = "0.4"
 walkdir = "2"
 regex = "1"
 
+# Symbol index (Phase 4)
+rusqlite = { version = "0.32", features = ["bundled"] }
+tree-sitter = "0.24"
+tree-sitter-typescript = "0.23"
+tree-sitter-javascript = "0.23"
+tree-sitter-rust = "0.23"
+tree-sitter-python = "0.23"
+tree-sitter-go = "0.23"
+tree-sitter-json = "0.24"
+sha2 = "0.10"
+
 [dev-dependencies]
 tempfile = "3"
 tokio-test = "0.4"
@@ -99,6 +110,10 @@ harness = false
 
 [[bench]]
 name = "agent"
+harness = false
+
+[[bench]]
+name = "symbol_index"
 harness = false
 
 [profile.release]

--- a/codi-rs/benches/symbol_index.rs
+++ b/codi-rs/benches/symbol_index.rs
@@ -1,0 +1,514 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Benchmarks for the symbol index system.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tempfile::tempdir;
+use tokio::runtime::Runtime;
+use tokio::sync::Mutex;
+
+use codi::symbol_index::{
+    CodeSymbol, ExtractionMethod, IndexBuildOptions, Indexer, SymbolDatabase, SymbolIndexService,
+    SymbolKind, SymbolParser, SymbolVisibility,
+};
+
+/// Sample TypeScript code for parsing benchmarks.
+const SAMPLE_TS: &str = r#"
+import { Config, Options } from './config';
+import * as utils from '../utils';
+
+/**
+ * Greet someone by name.
+ */
+export function greet(name: string): string {
+    return `Hello, ${name}!`;
+}
+
+export class Greeter {
+    private name: string;
+    private config: Config;
+
+    constructor(name: string, config?: Config) {
+        this.name = name;
+        this.config = config ?? new Config();
+    }
+
+    greet(): string {
+        return greet(this.name);
+    }
+
+    async asyncGreet(): Promise<string> {
+        return new Promise(resolve => {
+            setTimeout(() => resolve(this.greet()), 100);
+        });
+    }
+}
+
+export interface GreetingOptions {
+    formal: boolean;
+    language: string;
+}
+
+export type GreetingType = 'formal' | 'casual' | 'friendly';
+
+export enum GreetingLevel {
+    Casual,
+    Normal,
+    Formal,
+}
+
+export const DEFAULT_NAME = 'World';
+"#;
+
+/// Sample Rust code for parsing benchmarks.
+const SAMPLE_RUST: &str = r#"
+//! Module documentation.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Greet someone by name.
+pub fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)
+}
+
+/// A greeter struct.
+pub struct Greeter {
+    name: String,
+    config: Config,
+}
+
+impl Greeter {
+    /// Create a new greeter.
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            config: Config::default(),
+        }
+    }
+
+    /// Greet using this greeter.
+    pub fn greet(&self) -> String {
+        greet(&self.name)
+    }
+}
+
+/// Configuration options.
+#[derive(Default)]
+pub struct Config {
+    debug: bool,
+    level: GreetingLevel,
+}
+
+/// Greeting level.
+pub enum GreetingLevel {
+    Casual,
+    Normal,
+    Formal,
+}
+
+/// A greeting trait.
+pub trait Greetable {
+    fn greet(&self) -> String;
+}
+
+impl Greetable for Greeter {
+    fn greet(&self) -> String {
+        self.greet()
+    }
+}
+
+pub const DEFAULT_NAME: &str = "World";
+"#;
+
+/// Sample Python code for parsing benchmarks.
+const SAMPLE_PYTHON: &str = r#"
+"""Module documentation."""
+
+from typing import Optional, List
+from dataclasses import dataclass
+import asyncio
+
+
+def greet(name: str) -> str:
+    """Greet someone by name."""
+    return f"Hello, {name}!"
+
+
+class Greeter:
+    """A greeter class."""
+
+    def __init__(self, name: str, config: Optional["Config"] = None):
+        self.name = name
+        self.config = config or Config()
+
+    def greet(self) -> str:
+        """Greet using this greeter."""
+        return greet(self.name)
+
+    async def async_greet(self) -> str:
+        """Async greet."""
+        await asyncio.sleep(0.1)
+        return self.greet()
+
+
+@dataclass
+class Config:
+    """Configuration options."""
+    debug: bool = False
+    level: str = "normal"
+
+
+DEFAULT_NAME = "World"
+"#;
+
+fn bench_parser_new(c: &mut Criterion) {
+    c.bench_function("parser_new", |b| {
+        b.iter(|| {
+            let parser = SymbolParser::new().unwrap();
+            black_box(parser)
+        })
+    });
+}
+
+fn bench_parse_typescript(c: &mut Criterion) {
+    let mut parser = SymbolParser::new().unwrap();
+    let path = PathBuf::from("test.ts");
+
+    c.bench_function("parse_typescript", |b| {
+        b.iter(|| {
+            let result = parser.parse_file(&path, black_box(SAMPLE_TS)).unwrap();
+            black_box(result)
+        })
+    });
+}
+
+fn bench_parse_rust(c: &mut Criterion) {
+    let mut parser = SymbolParser::new().unwrap();
+    let path = PathBuf::from("test.rs");
+
+    c.bench_function("parse_rust", |b| {
+        b.iter(|| {
+            let result = parser.parse_file(&path, black_box(SAMPLE_RUST)).unwrap();
+            black_box(result)
+        })
+    });
+}
+
+fn bench_parse_python(c: &mut Criterion) {
+    let mut parser = SymbolParser::new().unwrap();
+    let path = PathBuf::from("test.py");
+
+    c.bench_function("parse_python", |b| {
+        b.iter(|| {
+            let result = parser.parse_file(&path, black_box(SAMPLE_PYTHON)).unwrap();
+            black_box(result)
+        })
+    });
+}
+
+fn bench_parse_various_sizes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse_file_size");
+    let mut parser = SymbolParser::new().unwrap();
+    let path = PathBuf::from("test.ts");
+
+    for size in [10, 50, 100, 200] {
+        let content = generate_ts_file(size);
+        group.throughput(Throughput::Bytes(content.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &content, |b, content| {
+            b.iter(|| {
+                let result = parser.parse_file(&path, black_box(content)).unwrap();
+                black_box(result)
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_database_open(c: &mut Criterion) {
+    let temp = tempdir().unwrap();
+    let project_root = temp.path().to_str().unwrap();
+
+    c.bench_function("database_open", |b| {
+        b.iter(|| {
+            let db = SymbolDatabase::open(black_box(project_root)).unwrap();
+            black_box(db)
+        })
+    });
+}
+
+fn bench_database_upsert_file(c: &mut Criterion) {
+    let temp = tempdir().unwrap();
+    let project_root = temp.path().to_str().unwrap();
+    let db = SymbolDatabase::open(project_root).unwrap();
+
+    c.bench_function("database_upsert_file", |b| {
+        let mut counter = 0u64;
+        b.iter(|| {
+            counter += 1;
+            let path = format!("src/file_{}.ts", counter);
+            let hash = format!("hash_{}", counter);
+            let file_id = db
+                .upsert_file(&path, &hash, ExtractionMethod::TreeSitter)
+                .unwrap();
+            black_box(file_id)
+        })
+    });
+}
+
+fn bench_database_insert_symbols(c: &mut Criterion) {
+    let temp = tempdir().unwrap();
+    let project_root = temp.path().to_str().unwrap();
+    let db = SymbolDatabase::open(project_root).unwrap();
+    let file_id = db
+        .upsert_file("test.ts", "hash", ExtractionMethod::TreeSitter)
+        .unwrap();
+
+    let symbols = generate_symbols(50);
+
+    c.bench_function("database_insert_symbols_50", |b| {
+        b.iter(|| {
+            db.insert_symbols(file_id, black_box(&symbols)).unwrap();
+        })
+    });
+}
+
+fn bench_database_find_symbols(c: &mut Criterion) {
+    let temp = tempdir().unwrap();
+    let project_root = temp.path().to_str().unwrap();
+    let db = SymbolDatabase::open(project_root).unwrap();
+
+    // Insert some symbols
+    let file_id = db
+        .upsert_file("test.ts", "hash", ExtractionMethod::TreeSitter)
+        .unwrap();
+    let symbols = generate_symbols(100);
+    db.insert_symbols(file_id, &symbols).unwrap();
+
+    c.bench_function("database_find_symbols", |b| {
+        b.iter(|| {
+            let results = db.find_symbols(black_box("Symbol"), 20).unwrap();
+            black_box(results)
+        })
+    });
+}
+
+fn bench_database_get_stats(c: &mut Criterion) {
+    let temp = tempdir().unwrap();
+    let project_root = temp.path().to_str().unwrap();
+    let db = SymbolDatabase::open(project_root).unwrap();
+
+    // Insert some data
+    let file_id = db
+        .upsert_file("test.ts", "hash", ExtractionMethod::TreeSitter)
+        .unwrap();
+    db.insert_symbols(file_id, &generate_symbols(50)).unwrap();
+
+    c.bench_function("database_get_stats", |b| {
+        b.iter(|| {
+            let stats = db.get_stats().unwrap();
+            black_box(stats)
+        })
+    });
+}
+
+fn bench_indexer_collect_files(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    let temp = tempdir().unwrap();
+    let project_root = temp.path();
+
+    // Create some test files
+    fs::create_dir(project_root.join("src")).unwrap();
+    for i in 0..50 {
+        fs::write(project_root.join(format!("src/file_{}.ts", i)), SAMPLE_TS).unwrap();
+    }
+
+    let options = IndexBuildOptions {
+        project_root: project_root.to_str().unwrap().to_string(),
+        ..Default::default()
+    };
+    let indexer = Indexer::new(options).unwrap();
+
+    c.bench_function("indexer_collect_files", |b| {
+        b.iter(|| {
+            // Access private method via reflection or test helper
+            // For now, we benchmark the full index_all which includes collection
+        })
+    });
+}
+
+fn bench_service_build(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    let mut group = c.benchmark_group("service_build");
+
+    for file_count in [10, 50, 100] {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        // Create test files
+        fs::create_dir(project_root.join("src")).unwrap();
+        for i in 0..file_count {
+            fs::write(project_root.join(format!("src/file_{}.ts", i)), SAMPLE_TS).unwrap();
+        }
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(file_count),
+            &project_root,
+            |b, project_root| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let service = SymbolIndexService::new(project_root.to_str().unwrap())
+                            .await
+                            .unwrap();
+                        let result = service.build(true).await.unwrap();
+                        black_box(result)
+                    })
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_service_find_symbols(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    let temp = tempdir().unwrap();
+    let project_root = temp.path();
+
+    // Create test files with symbols
+    fs::create_dir(project_root.join("src")).unwrap();
+    for i in 0..20 {
+        fs::write(project_root.join(format!("src/file_{}.ts", i)), SAMPLE_TS).unwrap();
+    }
+
+    let service = rt.block_on(async {
+        let service = SymbolIndexService::new(project_root.to_str().unwrap())
+            .await
+            .unwrap();
+        service.build(false).await.unwrap();
+        service
+    });
+
+    c.bench_function("service_find_symbols", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let results = service.find_symbols(black_box("Greeter"), None).await.unwrap();
+                black_box(results)
+            })
+        })
+    });
+}
+
+fn bench_service_get_stats(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    let temp = tempdir().unwrap();
+    let project_root = temp.path();
+
+    fs::write(project_root.join("test.ts"), SAMPLE_TS).unwrap();
+
+    let service = rt.block_on(async {
+        let service = SymbolIndexService::new(project_root.to_str().unwrap())
+            .await
+            .unwrap();
+        service.build(false).await.unwrap();
+        service
+    });
+
+    c.bench_function("service_get_stats", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let stats = service.get_stats().await.unwrap();
+                black_box(stats)
+            })
+        })
+    });
+}
+
+// Helper functions
+
+fn generate_ts_file(function_count: usize) -> String {
+    let mut content = String::new();
+    content.push_str("import { Config } from './config';\n\n");
+
+    for i in 0..function_count {
+        content.push_str(&format!(
+            r#"
+export function func{}(arg: string): string {{
+    return arg.toUpperCase();
+}}
+"#,
+            i
+        ));
+    }
+
+    for i in 0..function_count / 4 {
+        content.push_str(&format!(
+            r#"
+export class Class{} {{
+    private value: number;
+
+    constructor() {{
+        this.value = {};
+    }}
+
+    getValue(): number {{
+        return this.value;
+    }}
+}}
+"#,
+            i, i
+        ));
+    }
+
+    content
+}
+
+fn generate_symbols(count: usize) -> Vec<CodeSymbol> {
+    (0..count)
+        .map(|i| CodeSymbol {
+            name: format!("Symbol{}", i),
+            kind: if i % 3 == 0 {
+                SymbolKind::Function
+            } else if i % 3 == 1 {
+                SymbolKind::Class
+            } else {
+                SymbolKind::Interface
+            },
+            line: (i + 1) as u32,
+            end_line: Some((i + 10) as u32),
+            column: 0,
+            visibility: SymbolVisibility::Public,
+            signature: Some(format!("function Symbol{}(): void", i)),
+            doc_summary: Some(format!("Documentation for Symbol{}", i)),
+            metadata: None,
+        })
+        .collect()
+}
+
+criterion_group!(
+    benches,
+    bench_parser_new,
+    bench_parse_typescript,
+    bench_parse_rust,
+    bench_parse_python,
+    bench_parse_various_sizes,
+    bench_database_open,
+    bench_database_upsert_file,
+    bench_database_insert_symbols,
+    bench_database_find_symbols,
+    bench_database_get_stats,
+    bench_service_build,
+    bench_service_find_symbols,
+    bench_service_get_stats,
+);
+
+criterion_main!(benches);

--- a/codi-rs/src/lib.rs
+++ b/codi-rs/src/lib.rs
@@ -18,6 +18,7 @@
 //! - [`telemetry`] - Tracing, metrics, and observability infrastructure
 //! - [`tools`] - Tool handlers and registry
 //! - [`agent`] - Core agentic orchestration loop
+//! - [`symbol_index`] - Tree-sitter based code navigation and symbol search
 //!
 //! # Migration Status
 //!
@@ -26,8 +27,8 @@
 //! - **Phase 0**: Foundation - types, errors, config, CLI shell ✓
 //! - **Phase 1**: Tool layer - file tools, grep, glob, bash ✓
 //! - **Phase 2**: Provider layer - Anthropic, OpenAI, Ollama ✓
-//! - **Phase 3** (Current): Agent loop - core agentic orchestration
-//! - **Phase 4**: Symbol index - tree-sitter based code navigation
+//! - **Phase 3**: Agent loop - core agentic orchestration ✓
+//! - **Phase 4** (Current): Symbol index - tree-sitter based code navigation
 //! - **Phase 5**: RAG system - vector search with lance
 //! - **Phase 6**: Terminal UI - ratatui based interface
 //! - **Phase 7**: Multi-agent - IPC-based worker orchestration
@@ -49,6 +50,7 @@ pub mod agent;
 pub mod config;
 pub mod error;
 pub mod providers;
+pub mod symbol_index;
 pub mod telemetry;
 pub mod tools;
 pub mod types;
@@ -74,7 +76,7 @@ pub use types::{
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Migration phase identifier.
-pub const MIGRATION_PHASE: u8 = 3;
+pub const MIGRATION_PHASE: u8 = 4;
 
 #[cfg(test)]
 mod tests {
@@ -87,7 +89,7 @@ mod tests {
 
     #[test]
     fn test_migration_phase() {
-        assert_eq!(MIGRATION_PHASE, 3);
+        assert_eq!(MIGRATION_PHASE, 4);
     }
 
     #[test]

--- a/codi-rs/src/symbol_index/database.rs
+++ b/codi-rs/src/symbol_index/database.rs
@@ -1,0 +1,647 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! SQLite database wrapper for the symbol index.
+//!
+//! Handles schema creation, migrations, and low-level queries.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use rusqlite::{Connection, params, OptionalExtension};
+use sha2::{Sha256, Digest};
+
+use crate::error::ToolError;
+
+#[cfg(feature = "telemetry")]
+use crate::telemetry::metrics::GLOBAL_METRICS;
+
+use super::types::{
+    CodeSymbol, ExtractionMethod, ImportStatement,
+    IndexStats, IndexedFile, SymbolKind, SymbolSearchResult,
+    SymbolVisibility,
+};
+
+/// Current index format version.
+pub const INDEX_VERSION: &str = "1.0.0";
+
+/// Get the index directory for a project.
+pub fn get_index_directory(project_root: &str) -> PathBuf {
+    let mut hasher = Sha256::new();
+    hasher.update(project_root.as_bytes());
+    let hash = format!("{:x}", hasher.finalize());
+    let hash_short = &hash[..8];
+
+    let project_name = Path::new(project_root)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".codi")
+        .join("symbol-index")
+        .join(format!("{}-{}", project_name, hash_short))
+}
+
+/// SQLite database wrapper for the symbol index.
+pub struct SymbolDatabase {
+    conn: Connection,
+    index_dir: PathBuf,
+    db_path: PathBuf,
+    project_root: String,
+}
+
+impl SymbolDatabase {
+    /// Open or create a symbol database for the given project.
+    pub fn open(project_root: &str) -> Result<Self, ToolError> {
+        let start = Instant::now();
+
+        let index_dir = get_index_directory(project_root);
+        let db_path = index_dir.join("symbols.db");
+
+        // Ensure directory exists
+        std::fs::create_dir_all(&index_dir).map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to create index directory: {}", e))
+        })?;
+
+        // Open database
+        let conn = Connection::open(&db_path).map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to open database: {}", e))
+        })?;
+
+        // Set pragmas for performance
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA foreign_keys = ON;
+             PRAGMA cache_size = -64000;"  // 64MB cache
+        ).map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to set pragmas: {}", e))
+        })?;
+
+        let mut db = Self {
+            conn,
+            index_dir,
+            db_path,
+            project_root: project_root.to_string(),
+        };
+
+        // Initialize schema if needed
+        db.initialize_schema()?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.db.open", start.elapsed());
+
+        Ok(db)
+    }
+
+    /// Get the database file path.
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
+    /// Get the index directory.
+    pub fn index_dir(&self) -> &Path {
+        &self.index_dir
+    }
+
+    /// Initialize the database schema.
+    fn initialize_schema(&mut self) -> Result<(), ToolError> {
+        let start = Instant::now();
+
+        // Check if schema exists
+        let table_exists: bool = self.conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='files'",
+                [],
+                |_| Ok(true),
+            )
+            .optional()
+            .map_err(|e| ToolError::ExecutionFailed(format!("Schema check failed: {}", e)))?
+            .unwrap_or(false);
+
+        if !table_exists {
+            self.create_schema()?;
+        }
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.db.init_schema", start.elapsed());
+
+        Ok(())
+    }
+
+    /// Create the database schema.
+    fn create_schema(&self) -> Result<(), ToolError> {
+        // Create tables and indexes first (no parameters needed)
+        self.conn.execute_batch(r#"
+            -- Files table
+            CREATE TABLE IF NOT EXISTS files (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                path TEXT UNIQUE NOT NULL,
+                hash TEXT NOT NULL,
+                extraction_method TEXT NOT NULL,
+                last_indexed TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            -- Symbols table
+            CREATE TABLE IF NOT EXISTS symbols (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                name TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                line INTEGER NOT NULL,
+                end_line INTEGER,
+                visibility TEXT NOT NULL,
+                signature TEXT,
+                doc_summary TEXT,
+                metadata TEXT
+            );
+
+            -- Imports table
+            CREATE TABLE IF NOT EXISTS imports (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                source_path TEXT NOT NULL,
+                resolved_file_id INTEGER REFERENCES files(id) ON DELETE SET NULL,
+                is_type_only INTEGER NOT NULL DEFAULT 0,
+                line INTEGER NOT NULL
+            );
+
+            -- Import symbols table
+            CREATE TABLE IF NOT EXISTS import_symbols (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                import_id INTEGER NOT NULL REFERENCES imports(id) ON DELETE CASCADE,
+                name TEXT NOT NULL,
+                alias TEXT,
+                is_default INTEGER NOT NULL DEFAULT 0,
+                is_namespace INTEGER NOT NULL DEFAULT 0
+            );
+
+            -- File dependencies table
+            CREATE TABLE IF NOT EXISTS file_dependencies (
+                from_file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                to_file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                type TEXT NOT NULL,
+                PRIMARY KEY (from_file_id, to_file_id, type)
+            );
+
+            -- Metadata table
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+
+            -- Create indexes for common queries
+            CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
+            CREATE INDEX IF NOT EXISTS idx_symbols_file_id ON symbols(file_id);
+            CREATE INDEX IF NOT EXISTS idx_symbols_kind ON symbols(kind);
+            CREATE INDEX IF NOT EXISTS idx_imports_file_id ON imports(file_id);
+            CREATE INDEX IF NOT EXISTS idx_imports_resolved ON imports(resolved_file_id);
+            CREATE INDEX IF NOT EXISTS idx_deps_from ON file_dependencies(from_file_id);
+            CREATE INDEX IF NOT EXISTS idx_deps_to ON file_dependencies(to_file_id);
+        "#).map_err(|e| ToolError::ExecutionFailed(format!("Failed to create schema: {}", e)))?;
+
+        // Insert metadata with parameters (separate statements)
+        self.conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('version', ?1)",
+            params![INDEX_VERSION],
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to set version: {}", e)))?;
+
+        self.conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('last_full_rebuild', datetime('now'))",
+            [],
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to set last_full_rebuild: {}", e)))?;
+
+        self.conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('last_update', datetime('now'))",
+            [],
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to set last_update: {}", e)))?;
+
+        Ok(())
+    }
+
+    /// Get or create a file record.
+    pub fn upsert_file(
+        &self,
+        path: &str,
+        hash: &str,
+        method: ExtractionMethod,
+    ) -> Result<i64, ToolError> {
+        let start = Instant::now();
+
+        // Try to insert, on conflict update
+        self.conn.execute(
+            "INSERT INTO files (path, hash, extraction_method, last_indexed)
+             VALUES (?1, ?2, ?3, datetime('now'))
+             ON CONFLICT(path) DO UPDATE SET
+                hash = excluded.hash,
+                extraction_method = excluded.extraction_method,
+                last_indexed = datetime('now')",
+            params![path, hash, method.as_str()],
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to upsert file: {}", e)))?;
+
+        // Always query for the actual ID (last_insert_rowid is unreliable for upsert)
+        let file_id: i64 = self.conn.query_row(
+            "SELECT id FROM files WHERE path = ?1",
+            params![path],
+            |row| row.get(0),
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to get file id: {}", e)))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.db.upsert_file", start.elapsed());
+
+        Ok(file_id)
+    }
+
+    /// Get a file by path.
+    pub fn get_file(&self, path: &str) -> Result<Option<IndexedFile>, ToolError> {
+        let start = Instant::now();
+
+        let result = self.conn.query_row(
+            "SELECT id, path, hash, extraction_method, last_indexed FROM files WHERE path = ?1",
+            params![path],
+            |row| {
+                Ok(IndexedFile {
+                    id: row.get(0)?,
+                    path: row.get(1)?,
+                    hash: row.get(2)?,
+                    extraction_method: ExtractionMethod::from_str(&row.get::<_, String>(3)?),
+                    last_indexed: row.get(4)?,
+                })
+            },
+        ).optional().map_err(|e| ToolError::ExecutionFailed(format!("Failed to get file: {}", e)))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.db.get_file", start.elapsed());
+
+        Ok(result)
+    }
+
+    /// Delete a file and its symbols.
+    pub fn delete_file(&self, file_id: i64) -> Result<(), ToolError> {
+        let start = Instant::now();
+
+        // Cascading deletes handle symbols, imports, etc.
+        self.conn.execute(
+            "DELETE FROM files WHERE id = ?1",
+            params![file_id],
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to delete file: {}", e)))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.db.delete_file", start.elapsed());
+
+        Ok(())
+    }
+
+    /// Insert symbols for a file.
+    pub fn insert_symbols(&self, file_id: i64, symbols: &[CodeSymbol]) -> Result<(), ToolError> {
+        let start = Instant::now();
+
+        // Delete existing symbols for this file
+        self.conn.execute(
+            "DELETE FROM symbols WHERE file_id = ?1",
+            params![file_id],
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to delete old symbols: {}", e)))?;
+
+        // Insert new symbols
+        let mut stmt = self.conn.prepare(
+            "INSERT INTO symbols (file_id, name, kind, line, end_line, visibility, signature, doc_summary, metadata)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)"
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to prepare statement: {}", e)))?;
+
+        for symbol in symbols {
+            let metadata_json = symbol.metadata.as_ref().map(|m| m.to_string());
+
+            stmt.execute(params![
+                file_id,
+                symbol.name,
+                symbol.kind.as_str(),
+                symbol.line,
+                symbol.end_line,
+                symbol.visibility.as_str(),
+                symbol.signature,
+                symbol.doc_summary,
+                metadata_json,
+            ]).map_err(|e| ToolError::ExecutionFailed(format!("Failed to insert symbol: {}", e)))?;
+        }
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.db.insert_symbols", start.elapsed());
+
+        Ok(())
+    }
+
+    /// Insert imports for a file.
+    pub fn insert_imports(&self, file_id: i64, imports: &[ImportStatement]) -> Result<(), ToolError> {
+        let start = Instant::now();
+
+        // Delete existing imports for this file
+        self.conn.execute(
+            "DELETE FROM imports WHERE file_id = ?1",
+            params![file_id],
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to delete old imports: {}", e)))?;
+
+        let mut import_stmt = self.conn.prepare(
+            "INSERT INTO imports (file_id, source_path, is_type_only, line)
+             VALUES (?1, ?2, ?3, ?4)"
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to prepare import statement: {}", e)))?;
+
+        let mut symbol_stmt = self.conn.prepare(
+            "INSERT INTO import_symbols (import_id, name, alias, is_default, is_namespace)
+             VALUES (?1, ?2, ?3, ?4, ?5)"
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to prepare import symbol statement: {}", e)))?;
+
+        for import in imports {
+            import_stmt.execute(params![
+                file_id,
+                import.source,
+                import.is_type_only as i32,
+                import.line,
+            ]).map_err(|e| ToolError::ExecutionFailed(format!("Failed to insert import: {}", e)))?;
+
+            let import_id = self.conn.last_insert_rowid();
+
+            for sym in &import.symbols {
+                symbol_stmt.execute(params![
+                    import_id,
+                    sym.name,
+                    sym.alias,
+                    sym.is_default as i32,
+                    sym.is_namespace as i32,
+                ]).map_err(|e| ToolError::ExecutionFailed(format!("Failed to insert import symbol: {}", e)))?;
+            }
+        }
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.db.insert_imports", start.elapsed());
+
+        Ok(())
+    }
+
+    /// Search for symbols by name (fuzzy search).
+    pub fn find_symbols(&self, query: &str, limit: usize) -> Result<Vec<SymbolSearchResult>, ToolError> {
+        let start = Instant::now();
+
+        // Use LIKE for simple fuzzy search
+        let pattern = format!("%{}%", query);
+
+        let mut stmt = self.conn.prepare(
+            "SELECT s.name, s.kind, f.path, s.line, s.end_line, s.visibility, s.signature, s.doc_summary
+             FROM symbols s
+             JOIN files f ON s.file_id = f.id
+             WHERE s.name LIKE ?1
+             ORDER BY
+                CASE WHEN s.name = ?2 THEN 0
+                     WHEN s.name LIKE ?3 THEN 1
+                     ELSE 2 END,
+                length(s.name)
+             LIMIT ?4"
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to prepare query: {}", e)))?;
+
+        let exact_pattern = query;
+        let starts_with_pattern = format!("{}%", query);
+
+        let results = stmt.query_map(
+            params![pattern, exact_pattern, starts_with_pattern, limit as i64],
+            |row| {
+                let name: String = row.get(0)?;
+                let score = if name == query {
+                    1.0
+                } else if name.starts_with(query) {
+                    0.8
+                } else {
+                    0.5
+                };
+
+                Ok(SymbolSearchResult {
+                    name,
+                    kind: SymbolKind::from_str(&row.get::<_, String>(1)?),
+                    file: row.get(2)?,
+                    line: row.get(3)?,
+                    end_line: row.get(4)?,
+                    visibility: SymbolVisibility::from_str(&row.get::<_, String>(5)?),
+                    signature: row.get(6)?,
+                    doc_summary: row.get(7)?,
+                    score,
+                })
+            },
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Query failed: {}", e)))?;
+
+        let results: Vec<_> = results
+            .filter_map(|r| r.ok())
+            .collect();
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.db.find_symbols", start.elapsed());
+
+        Ok(results)
+    }
+
+    /// Get index statistics.
+    pub fn get_stats(&self) -> Result<IndexStats, ToolError> {
+        let start = Instant::now();
+
+        let total_files: u32 = self.conn
+            .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to count files: {}", e)))?;
+
+        let total_symbols: u32 = self.conn
+            .query_row("SELECT COUNT(*) FROM symbols", [], |row| row.get(0))
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to count symbols: {}", e)))?;
+
+        let total_imports: u32 = self.conn
+            .query_row("SELECT COUNT(*) FROM imports", [], |row| row.get(0))
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to count imports: {}", e)))?;
+
+        let total_dependencies: u32 = self.conn
+            .query_row("SELECT COUNT(*) FROM file_dependencies", [], |row| row.get(0))
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to count dependencies: {}", e)))?;
+
+        let version: String = self.conn
+            .query_row("SELECT value FROM metadata WHERE key = 'version'", [], |row| row.get(0))
+            .unwrap_or_else(|_| INDEX_VERSION.to_string());
+
+        let last_full_rebuild: String = self.conn
+            .query_row("SELECT value FROM metadata WHERE key = 'last_full_rebuild'", [], |row| row.get(0))
+            .unwrap_or_else(|_| "never".to_string());
+
+        let last_update: String = self.conn
+            .query_row("SELECT value FROM metadata WHERE key = 'last_update'", [], |row| row.get(0))
+            .unwrap_or_else(|_| "never".to_string());
+
+        let index_size_bytes = std::fs::metadata(&self.db_path)
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.db.get_stats", start.elapsed());
+
+        Ok(IndexStats {
+            version,
+            project_root: self.project_root.clone(),
+            total_files,
+            total_symbols,
+            total_imports,
+            total_dependencies,
+            last_full_rebuild,
+            last_update,
+            index_size_bytes,
+        })
+    }
+
+    /// Update the last_update timestamp.
+    pub fn touch_update(&self) -> Result<(), ToolError> {
+        self.conn.execute(
+            "UPDATE metadata SET value = datetime('now') WHERE key = 'last_update'",
+            [],
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to update timestamp: {}", e)))?;
+        Ok(())
+    }
+
+    /// Clear the entire index.
+    pub fn clear(&self) -> Result<(), ToolError> {
+        let start = Instant::now();
+
+        self.conn.execute_batch(
+            "DELETE FROM file_dependencies;
+             DELETE FROM import_symbols;
+             DELETE FROM imports;
+             DELETE FROM symbols;
+             DELETE FROM files;
+             UPDATE metadata SET value = datetime('now') WHERE key = 'last_full_rebuild';
+             UPDATE metadata SET value = datetime('now') WHERE key = 'last_update';"
+        ).map_err(|e| ToolError::ExecutionFailed(format!("Failed to clear index: {}", e)))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.db.clear", start.elapsed());
+
+        Ok(())
+    }
+
+    /// Begin a transaction.
+    pub fn begin_transaction(&mut self) -> Result<(), ToolError> {
+        self.conn.execute("BEGIN TRANSACTION", [])
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to begin transaction: {}", e)))?;
+        Ok(())
+    }
+
+    /// Commit the current transaction.
+    pub fn commit(&mut self) -> Result<(), ToolError> {
+        self.conn.execute("COMMIT", [])
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to commit: {}", e)))?;
+        Ok(())
+    }
+
+    /// Rollback the current transaction.
+    pub fn rollback(&mut self) -> Result<(), ToolError> {
+        self.conn.execute("ROLLBACK", [])
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to rollback: {}", e)))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_get_index_directory() {
+        let dir = get_index_directory("/home/user/project");
+        assert!(dir.to_str().unwrap().contains("symbol-index"));
+        assert!(dir.to_str().unwrap().contains("project"));
+    }
+
+    #[test]
+    fn test_database_open() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path().to_str().unwrap();
+
+        let db = SymbolDatabase::open(project_root).unwrap();
+        assert!(db.db_path().exists());
+    }
+
+    #[test]
+    fn test_file_operations() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path().to_str().unwrap();
+
+        let db = SymbolDatabase::open(project_root).unwrap();
+
+        // Insert file
+        let file_id = db.upsert_file("src/main.rs", "abc123", ExtractionMethod::TreeSitter).unwrap();
+        assert!(file_id > 0);
+
+        // Get file
+        let file = db.get_file("src/main.rs").unwrap().unwrap();
+        assert_eq!(file.path, "src/main.rs");
+        assert_eq!(file.hash, "abc123");
+
+        // Update file
+        let file_id2 = db.upsert_file("src/main.rs", "def456", ExtractionMethod::TreeSitter).unwrap();
+        assert_eq!(file_id, file_id2);
+
+        let file = db.get_file("src/main.rs").unwrap().unwrap();
+        assert_eq!(file.hash, "def456");
+    }
+
+    #[test]
+    fn test_symbol_operations() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path().to_str().unwrap();
+
+        let db = SymbolDatabase::open(project_root).unwrap();
+
+        let file_id = db.upsert_file("src/lib.rs", "hash", ExtractionMethod::TreeSitter).unwrap();
+
+        let symbols = vec![
+            CodeSymbol {
+                name: "main".to_string(),
+                kind: SymbolKind::Function,
+                line: 1,
+                end_line: Some(10),
+                column: 0,
+                visibility: SymbolVisibility::Public,
+                signature: Some("fn main()".to_string()),
+                doc_summary: None,
+                metadata: None,
+            },
+            CodeSymbol {
+                name: "Config".to_string(),
+                kind: SymbolKind::Struct,
+                line: 12,
+                end_line: Some(20),
+                column: 0,
+                visibility: SymbolVisibility::Public,
+                signature: Some("struct Config".to_string()),
+                doc_summary: Some("Configuration struct".to_string()),
+                metadata: None,
+            },
+        ];
+
+        db.insert_symbols(file_id, &symbols).unwrap();
+
+        // Search for symbols
+        let results = db.find_symbols("main", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "main");
+
+        let results = db.find_symbols("Config", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].kind, SymbolKind::Struct);
+    }
+
+    #[test]
+    fn test_stats() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path().to_str().unwrap();
+
+        let db = SymbolDatabase::open(project_root).unwrap();
+
+        let stats = db.get_stats().unwrap();
+        assert_eq!(stats.total_files, 0);
+        assert_eq!(stats.total_symbols, 0);
+        assert_eq!(stats.version, INDEX_VERSION);
+    }
+}

--- a/codi-rs/src/symbol_index/indexer.rs
+++ b/codi-rs/src/symbol_index/indexer.rs
@@ -1,0 +1,803 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Background indexer for the symbol index.
+//!
+//! Provides parallel file indexing using tokio tasks and incremental updates.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use sha2::{Digest, Sha256};
+use tokio::sync::{mpsc, Mutex};
+use walkdir::WalkDir;
+
+use crate::error::ToolError;
+
+#[cfg(feature = "telemetry")]
+use crate::telemetry::metrics::GLOBAL_METRICS;
+
+use super::database::SymbolDatabase;
+use super::parser::SymbolParser;
+use super::types::{IndexBuildOptions, Language};
+
+/// Progress callback for indexing operations.
+pub type ProgressCallback = Box<dyn Fn(IndexProgress) + Send + Sync>;
+
+/// Indexing progress update.
+#[derive(Debug, Clone)]
+pub struct IndexProgress {
+    /// Current file being processed.
+    pub current_file: Option<String>,
+    /// Number of files processed.
+    pub files_processed: u32,
+    /// Total number of files to process.
+    pub total_files: u32,
+    /// Number of symbols extracted.
+    pub symbols_extracted: u32,
+    /// Whether indexing is complete.
+    pub is_complete: bool,
+    /// Error message if any.
+    pub error: Option<String>,
+}
+
+/// Result of an indexing operation.
+#[derive(Debug, Clone)]
+pub struct IndexResult {
+    /// Number of files indexed.
+    pub files_indexed: u32,
+    /// Number of files skipped (unchanged).
+    pub files_skipped: u32,
+    /// Number of files with errors.
+    pub files_errored: u32,
+    /// Total symbols extracted.
+    pub total_symbols: u32,
+    /// Total imports extracted.
+    pub total_imports: u32,
+    /// Indexing duration in milliseconds.
+    pub duration_ms: u64,
+}
+
+/// File to be indexed.
+#[derive(Debug, Clone)]
+struct FileToIndex {
+    path: PathBuf,
+    relative_path: String,
+}
+
+/// Background indexer for symbol extraction.
+pub struct Indexer {
+    options: IndexBuildOptions,
+    include_globs: GlobSet,
+    exclude_globs: GlobSet,
+    is_running: Arc<AtomicBool>,
+    files_processed: Arc<AtomicU32>,
+    symbols_extracted: Arc<AtomicU32>,
+}
+
+impl Indexer {
+    /// Create a new indexer with the given options.
+    pub fn new(options: IndexBuildOptions) -> Result<Self, ToolError> {
+        let start = Instant::now();
+
+        let include_globs = Self::build_globset(&options.include_patterns)?;
+        let exclude_globs = Self::build_globset(&options.exclude_patterns)?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.indexer.new", start.elapsed());
+
+        Ok(Self {
+            options,
+            include_globs,
+            exclude_globs,
+            is_running: Arc::new(AtomicBool::new(false)),
+            files_processed: Arc::new(AtomicU32::new(0)),
+            symbols_extracted: Arc::new(AtomicU32::new(0)),
+        })
+    }
+
+    /// Build a globset from patterns.
+    fn build_globset(patterns: &[String]) -> Result<GlobSet, ToolError> {
+        let mut builder = GlobSetBuilder::new();
+        for pattern in patterns {
+            let glob = Glob::new(pattern).map_err(|e| {
+                ToolError::InvalidInput(format!("Invalid glob pattern '{}': {}", pattern, e))
+            })?;
+            builder.add(glob);
+        }
+        builder.build().map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to build globset: {}", e))
+        })
+    }
+
+    /// Check if indexing is currently running.
+    pub fn is_running(&self) -> bool {
+        self.is_running.load(Ordering::SeqCst)
+    }
+
+    /// Get current progress.
+    pub fn get_progress(&self) -> (u32, u32) {
+        (
+            self.files_processed.load(Ordering::SeqCst),
+            self.symbols_extracted.load(Ordering::SeqCst),
+        )
+    }
+
+    /// Cancel the current indexing operation.
+    pub fn cancel(&self) {
+        self.is_running.store(false, Ordering::SeqCst);
+    }
+
+    /// Index all files in the project.
+    pub async fn index_all(
+        &self,
+        db: Arc<Mutex<SymbolDatabase>>,
+        progress_callback: Option<ProgressCallback>,
+    ) -> Result<IndexResult, ToolError> {
+        let start = Instant::now();
+
+        // Reset state
+        self.is_running.store(true, Ordering::SeqCst);
+        self.files_processed.store(0, Ordering::SeqCst);
+        self.symbols_extracted.store(0, Ordering::SeqCst);
+
+        // Collect files to index
+        let files = self.collect_files()?;
+        let total_files = files.len() as u32;
+
+        // Report initial progress
+        if let Some(ref callback) = progress_callback {
+            callback(IndexProgress {
+                current_file: None,
+                files_processed: 0,
+                total_files,
+                symbols_extracted: 0,
+                is_complete: false,
+                error: None,
+            });
+        }
+
+        // Clear index if force rebuild
+        if self.options.force_rebuild {
+            let db_lock = db.lock().await;
+            db_lock.clear()?;
+        }
+
+        // Create work channel
+        let (tx, rx) = mpsc::channel::<FileToIndex>(self.options.parallel_jobs * 2);
+        let rx = Arc::new(Mutex::new(rx));
+
+        // Shared result counters
+        let files_indexed = Arc::new(AtomicU32::new(0));
+        let files_skipped = Arc::new(AtomicU32::new(0));
+        let files_errored = Arc::new(AtomicU32::new(0));
+        let total_symbols = Arc::new(AtomicU32::new(0));
+        let total_imports = Arc::new(AtomicU32::new(0));
+
+        // Spawn worker tasks
+        let mut handles = Vec::new();
+        for _ in 0..self.options.parallel_jobs {
+            let rx_clone = rx.clone();
+            let db_clone = db.clone();
+            let is_running = self.is_running.clone();
+            let files_processed = self.files_processed.clone();
+            let symbols_extracted = self.symbols_extracted.clone();
+            let files_indexed_clone = files_indexed.clone();
+            let files_skipped_clone = files_skipped.clone();
+            let files_errored_clone = files_errored.clone();
+            let total_symbols_clone = total_symbols.clone();
+            let total_imports_clone = total_imports.clone();
+            let force_rebuild = self.options.force_rebuild;
+            let _progress_callback = progress_callback.as_ref().map(|_| {
+                // We can't clone the callback, so we use a channel instead
+                ()
+            });
+
+            let handle = tokio::spawn(async move {
+                // Create parser for this worker
+                let mut parser = match SymbolParser::new() {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::error!("Failed to create parser: {}", e);
+                        return;
+                    }
+                };
+
+                loop {
+                    if !is_running.load(Ordering::SeqCst) {
+                        break;
+                    }
+
+                    let file = {
+                        let mut rx_lock = rx_clone.lock().await;
+                        rx_lock.recv().await
+                    };
+
+                    match file {
+                        Some(file_info) => {
+                            let result = Self::process_file(
+                                &file_info,
+                                &mut parser,
+                                &db_clone,
+                                force_rebuild,
+                            ).await;
+
+                            match result {
+                                Ok((indexed, symbol_count, import_count)) => {
+                                    if indexed {
+                                        files_indexed_clone.fetch_add(1, Ordering::SeqCst);
+                                        total_symbols_clone.fetch_add(symbol_count, Ordering::SeqCst);
+                                        total_imports_clone.fetch_add(import_count, Ordering::SeqCst);
+                                        symbols_extracted.fetch_add(symbol_count, Ordering::SeqCst);
+                                    } else {
+                                        files_skipped_clone.fetch_add(1, Ordering::SeqCst);
+                                    }
+                                }
+                                Err(e) => {
+                                    files_errored_clone.fetch_add(1, Ordering::SeqCst);
+                                    tracing::warn!("Error indexing {}: {}", file_info.relative_path, e);
+                                }
+                            }
+
+                            files_processed.fetch_add(1, Ordering::SeqCst);
+                        }
+                        None => break,
+                    }
+                }
+            });
+
+            handles.push(handle);
+        }
+
+        // Send files to workers
+        for file in files {
+            if !self.is_running.load(Ordering::SeqCst) {
+                break;
+            }
+
+            if tx.send(file).await.is_err() {
+                break;
+            }
+        }
+
+        // Drop sender to signal completion
+        drop(tx);
+
+        // Wait for all workers to complete
+        for handle in handles {
+            let _ = handle.await;
+        }
+
+        // Mark as complete
+        self.is_running.store(false, Ordering::SeqCst);
+
+        // Update database timestamp
+        {
+            let db_lock = db.lock().await;
+            db_lock.touch_update()?;
+        }
+
+        let duration = start.elapsed();
+        let result = IndexResult {
+            files_indexed: files_indexed.load(Ordering::SeqCst),
+            files_skipped: files_skipped.load(Ordering::SeqCst),
+            files_errored: files_errored.load(Ordering::SeqCst),
+            total_symbols: total_symbols.load(Ordering::SeqCst),
+            total_imports: total_imports.load(Ordering::SeqCst),
+            duration_ms: duration.as_millis() as u64,
+        };
+
+        // Report final progress
+        if let Some(callback) = progress_callback {
+            callback(IndexProgress {
+                current_file: None,
+                files_processed: result.files_indexed + result.files_skipped,
+                total_files,
+                symbols_extracted: result.total_symbols,
+                is_complete: true,
+                error: None,
+            });
+        }
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.indexer.index_all", duration);
+
+        Ok(result)
+    }
+
+    /// Index specific files (for incremental updates).
+    pub async fn index_files(
+        &self,
+        db: Arc<Mutex<SymbolDatabase>>,
+        files: &[PathBuf],
+    ) -> Result<IndexResult, ToolError> {
+        let start = Instant::now();
+
+        let project_root = Path::new(&self.options.project_root);
+        let mut parser = SymbolParser::new()?;
+
+        let mut files_indexed = 0u32;
+        let mut files_skipped = 0u32;
+        let mut files_errored = 0u32;
+        let mut total_symbols = 0u32;
+        let mut total_imports = 0u32;
+
+        for path in files {
+            let relative_path = path
+                .strip_prefix(project_root)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .to_string();
+
+            let file_info = FileToIndex {
+                path: path.clone(),
+                relative_path,
+            };
+
+            match Self::process_file(&file_info, &mut parser, &db, false).await {
+                Ok((indexed, symbol_count, import_count)) => {
+                    if indexed {
+                        files_indexed += 1;
+                        total_symbols += symbol_count;
+                        total_imports += import_count;
+                    } else {
+                        files_skipped += 1;
+                    }
+                }
+                Err(e) => {
+                    files_errored += 1;
+                    tracing::warn!("Error indexing {}: {}", file_info.relative_path, e);
+                }
+            }
+        }
+
+        // Update database timestamp
+        {
+            let db_lock = db.lock().await;
+            db_lock.touch_update()?;
+        }
+
+        let duration = start.elapsed();
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.indexer.index_files", duration);
+
+        Ok(IndexResult {
+            files_indexed,
+            files_skipped,
+            files_errored,
+            total_symbols,
+            total_imports,
+            duration_ms: duration.as_millis() as u64,
+        })
+    }
+
+    /// Process a single file.
+    async fn process_file(
+        file_info: &FileToIndex,
+        parser: &mut SymbolParser,
+        db: &Arc<Mutex<SymbolDatabase>>,
+        force: bool,
+    ) -> Result<(bool, u32, u32), ToolError> {
+        let start = Instant::now();
+
+        // Read file content
+        let content = tokio::fs::read_to_string(&file_info.path).await.map_err(|e| {
+            ToolError::ExecutionFailed(format!(
+                "Failed to read file {}: {}",
+                file_info.path.display(),
+                e
+            ))
+        })?;
+
+        // Calculate hash
+        let hash = {
+            let mut hasher = Sha256::new();
+            hasher.update(content.as_bytes());
+            format!("{:x}", hasher.finalize())
+        };
+
+        // Check if file has changed
+        if !force {
+            let db_lock = db.lock().await;
+            if let Some(existing) = db_lock.get_file(&file_info.relative_path)? {
+                if existing.hash == hash {
+                    #[cfg(feature = "telemetry")]
+                    GLOBAL_METRICS.record_operation("symbol_index.indexer.skip_file", start.elapsed());
+                    return Ok((false, 0, 0));
+                }
+            }
+        }
+
+        // Parse file
+        let parse_result = parser.parse_file(&file_info.path, &content)?;
+
+        // Store in database
+        let db_lock = db.lock().await;
+
+        let file_id = db_lock.upsert_file(
+            &file_info.relative_path,
+            &parse_result.hash,
+            parse_result.method,
+        )?;
+
+        db_lock.insert_symbols(file_id, &parse_result.symbols)?;
+        db_lock.insert_imports(file_id, &parse_result.imports)?;
+
+        let symbol_count = parse_result.symbols.len() as u32;
+        let import_count = parse_result.imports.len() as u32;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.indexer.process_file", start.elapsed());
+
+        Ok((true, symbol_count, import_count))
+    }
+
+    /// Collect all files to index.
+    fn collect_files(&self) -> Result<Vec<FileToIndex>, ToolError> {
+        let start = Instant::now();
+
+        let project_root = Path::new(&self.options.project_root);
+        let mut files = Vec::new();
+
+        for entry in WalkDir::new(project_root)
+            .follow_links(false)
+            .into_iter()
+            .filter_entry(|e| {
+                // Don't exclude the root directory itself
+                if e.path() == project_root {
+                    return true;
+                }
+                // Get the relative path for exclusion check
+                let relative = e.path().strip_prefix(project_root).unwrap_or(e.path());
+                let excluded = self.should_exclude_relative(relative);
+                !excluded
+            })
+        {
+            let entry = entry.map_err(|e| {
+                ToolError::ExecutionFailed(format!("Failed to walk directory: {}", e))
+            })?;
+
+            if entry.file_type().is_file() {
+                let path = entry.path();
+
+                let relative_path = path
+                    .strip_prefix(project_root)
+                    .unwrap_or(path);
+
+                // Check if file matches include patterns (use relative path for matching)
+                if self.should_include_relative(relative_path) {
+                    files.push(FileToIndex {
+                        path: path.to_path_buf(),
+                        relative_path: relative_path.to_string_lossy().to_string(),
+                    });
+                }
+            }
+        }
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.indexer.collect_files", start.elapsed());
+
+        Ok(files)
+    }
+
+    /// Check if a relative path should be included.
+    fn should_include_relative(&self, relative_path: &Path) -> bool {
+        // Check file extension for supported languages
+        let ext = relative_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let lang = Language::from_extension(ext);
+        if matches!(lang, Language::Unknown) {
+            return false;
+        }
+
+        // Check against include patterns using relative path
+        self.include_globs.is_match(relative_path)
+    }
+
+    /// Check if a path should be included (legacy, for tests).
+    #[allow(dead_code)]
+    fn should_include(&self, path: &Path) -> bool {
+        self.should_include_relative(path)
+    }
+
+    /// Check if a relative path should be excluded.
+    fn should_exclude_relative(&self, relative_path: &Path) -> bool {
+        // Skip hidden files/directories (those starting with .)
+        if let Some(name) = relative_path.file_name() {
+            if name.to_string_lossy().starts_with('.') {
+                return true;
+            }
+        }
+
+        // Also check each path component for hidden directories
+        for component in relative_path.components() {
+            if let std::path::Component::Normal(name) = component {
+                if name.to_string_lossy().starts_with('.') {
+                    return true;
+                }
+            }
+        }
+
+        // Check against exclude patterns - try matching with filename for common dirs
+        if let Some(name) = relative_path.file_name() {
+            let name_str = name.to_string_lossy();
+            // Common directories to exclude
+            if matches!(
+                name_str.as_ref(),
+                "node_modules" | "target" | "dist" | "build" | "__pycache__" | "venv"
+            ) {
+                return true;
+            }
+        }
+
+        // Check against exclude patterns
+        self.exclude_globs.is_match(relative_path)
+    }
+
+    /// Check if a path should be excluded (legacy, for tests).
+    #[allow(dead_code)]
+    fn should_exclude(&self, path: &Path) -> bool {
+        self.should_exclude_relative(path)
+    }
+
+    /// Remove deleted files from the index.
+    pub async fn cleanup_deleted(
+        &self,
+        db: Arc<Mutex<SymbolDatabase>>,
+    ) -> Result<u32, ToolError> {
+        let start = Instant::now();
+
+        let _project_root = Path::new(&self.options.project_root);
+        let _db_lock = db.lock().await;
+
+        // Get all indexed files
+        // Note: We'd need to add a method to get all files from db
+        // For now, this is a placeholder
+        let deleted_count = 0u32;
+
+        // TODO: Implement file cleanup
+        // 1. Get all indexed file paths from database
+        // 2. Check which ones no longer exist on disk
+        // 3. Delete those from the database
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.indexer.cleanup_deleted", start.elapsed());
+
+        Ok(deleted_count)
+    }
+}
+
+/// Watch for file changes and trigger incremental indexing.
+pub struct FileWatcher {
+    project_root: PathBuf,
+    indexer: Arc<Indexer>,
+    db: Arc<Mutex<SymbolDatabase>>,
+    is_running: Arc<AtomicBool>,
+}
+
+impl FileWatcher {
+    /// Create a new file watcher.
+    pub fn new(
+        project_root: PathBuf,
+        indexer: Arc<Indexer>,
+        db: Arc<Mutex<SymbolDatabase>>,
+    ) -> Self {
+        Self {
+            project_root,
+            indexer,
+            db,
+            is_running: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Start watching for file changes.
+    pub async fn start(&self) -> Result<(), ToolError> {
+        let start = Instant::now();
+
+        self.is_running.store(true, Ordering::SeqCst);
+
+        // Note: Full file watching would require the `notify` crate
+        // For now, this is a stub that could be expanded
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.watcher.start", start.elapsed());
+
+        Ok(())
+    }
+
+    /// Stop watching for file changes.
+    pub fn stop(&self) {
+        self.is_running.store(false, Ordering::SeqCst);
+    }
+
+    /// Check if watcher is running.
+    pub fn is_running(&self) -> bool {
+        self.is_running.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use std::fs;
+
+    #[tokio::test]
+    async fn test_indexer_new() {
+        let options = IndexBuildOptions::default();
+        let indexer = Indexer::new(options);
+        assert!(indexer.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_collect_files() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        // Create test files
+        fs::write(project_root.join("main.ts"), "const x = 1;").unwrap();
+        fs::write(project_root.join("lib.rs"), "fn main() {}").unwrap();
+        fs::create_dir(project_root.join("node_modules")).unwrap();
+        fs::write(project_root.join("node_modules/pkg.js"), "// pkg").unwrap();
+
+        let options = IndexBuildOptions {
+            project_root: project_root.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+
+        let indexer = Indexer::new(options.clone()).unwrap();
+        let files = indexer.collect_files().unwrap();
+
+        // Should include main.ts and lib.rs, but not node_modules
+        assert_eq!(files.len(), 2);
+        let paths: Vec<&str> = files.iter().map(|f| f.relative_path.as_str()).collect();
+        assert!(paths.contains(&"main.ts"));
+        assert!(paths.contains(&"lib.rs"));
+    }
+
+    #[tokio::test]
+    async fn test_index_all() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        // Create test files
+        fs::write(
+            project_root.join("main.ts"),
+            r#"
+            export function hello() {
+                return "hello";
+            }
+
+            export class Greeter {
+                greet() {}
+            }
+            "#,
+        ).unwrap();
+
+        fs::write(
+            project_root.join("lib.rs"),
+            r#"
+            pub fn greet() -> String {
+                "hello".to_string()
+            }
+
+            pub struct Config {
+                name: String,
+            }
+            "#,
+        ).unwrap();
+
+        let options = IndexBuildOptions {
+            project_root: project_root.to_string_lossy().to_string(),
+            parallel_jobs: 2,
+            ..Default::default()
+        };
+
+        let indexer = Arc::new(Indexer::new(options.clone()).unwrap());
+        let db = Arc::new(Mutex::new(
+            SymbolDatabase::open(&options.project_root).unwrap()
+        ));
+
+        let result = indexer.index_all(db.clone(), None).await.unwrap();
+
+        assert_eq!(result.files_indexed, 2);
+        assert!(result.total_symbols >= 4); // At least hello, Greeter, greet, Config
+        assert_eq!(result.files_errored, 0);
+    }
+
+    #[tokio::test]
+    async fn test_incremental_indexing() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        // Create initial file
+        fs::write(project_root.join("main.ts"), "const a = 1;").unwrap();
+
+        let options = IndexBuildOptions {
+            project_root: project_root.to_string_lossy().to_string(),
+            parallel_jobs: 1,
+            ..Default::default()
+        };
+
+        let indexer = Arc::new(Indexer::new(options.clone()).unwrap());
+        let db = Arc::new(Mutex::new(
+            SymbolDatabase::open(&options.project_root).unwrap()
+        ));
+
+        // First index
+        let result1 = indexer.index_all(db.clone(), None).await.unwrap();
+        assert_eq!(result1.files_indexed, 1);
+
+        // Second index without changes should skip
+        let result2 = indexer.index_all(db.clone(), None).await.unwrap();
+        assert_eq!(result2.files_indexed, 0);
+        assert_eq!(result2.files_skipped, 1);
+
+        // Modify file
+        fs::write(project_root.join("main.ts"), "const b = 2;").unwrap();
+
+        // Third index should re-index the changed file
+        let result3 = indexer.index_all(db.clone(), None).await.unwrap();
+        assert_eq!(result3.files_indexed, 1);
+    }
+
+    #[tokio::test]
+    async fn test_force_rebuild() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        fs::write(project_root.join("main.ts"), "const a = 1;").unwrap();
+
+        let options = IndexBuildOptions {
+            project_root: project_root.to_string_lossy().to_string(),
+            parallel_jobs: 1,
+            force_rebuild: false,
+            ..Default::default()
+        };
+
+        let indexer = Arc::new(Indexer::new(options.clone()).unwrap());
+        let db = Arc::new(Mutex::new(
+            SymbolDatabase::open(&options.project_root).unwrap()
+        ));
+
+        // First index
+        indexer.index_all(db.clone(), None).await.unwrap();
+
+        // Create new indexer with force_rebuild
+        let options_force = IndexBuildOptions {
+            force_rebuild: true,
+            ..options
+        };
+        let indexer_force = Arc::new(Indexer::new(options_force).unwrap());
+
+        // Force rebuild should re-index even unchanged files
+        let result = indexer_force.index_all(db.clone(), None).await.unwrap();
+        assert_eq!(result.files_indexed, 1);
+    }
+
+    #[test]
+    fn test_should_exclude() {
+        let options = IndexBuildOptions::default();
+        let indexer = Indexer::new(options).unwrap();
+
+        assert!(indexer.should_exclude(Path::new(".git/config")));
+        assert!(indexer.should_exclude(Path::new("node_modules/pkg")));
+        assert!(indexer.should_exclude(Path::new("target/debug")));
+        assert!(!indexer.should_exclude(Path::new("src/main.rs")));
+    }
+
+    #[test]
+    fn test_should_include() {
+        let options = IndexBuildOptions::default();
+        let indexer = Indexer::new(options).unwrap();
+
+        assert!(indexer.should_include(Path::new("src/main.rs")));
+        assert!(indexer.should_include(Path::new("lib/utils.ts")));
+        assert!(indexer.should_include(Path::new("tests/test.py")));
+        assert!(!indexer.should_include(Path::new("README.md")));
+        assert!(!indexer.should_include(Path::new("data.json")));
+    }
+}

--- a/codi-rs/src/symbol_index/mod.rs
+++ b/codi-rs/src/symbol_index/mod.rs
@@ -1,0 +1,254 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Symbol index system for code navigation.
+//!
+//! This module provides a fast, multi-language symbol index using tree-sitter
+//! for AST parsing and SQLite for storage. It supports:
+//!
+//! - **Multi-language support**: TypeScript, JavaScript, Rust, Python, Go
+//! - **Symbol extraction**: Functions, classes, structs, enums, interfaces, etc.
+//! - **Import tracking**: Import statements with resolution
+//! - **Fuzzy search**: Find symbols by name with fuzzy matching
+//! - **Incremental updates**: Only re-index changed files
+//! - **Background indexing**: Parallel indexing with progress tracking
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────┐
+//! │                  SymbolIndexService                      │
+//! │  (High-level API: build, find_symbols, get_stats, etc.) │
+//! └─────────────────────────────────────────────────────────┘
+//!                            │
+//!          ┌─────────────────┼─────────────────┐
+//!          ▼                 ▼                 ▼
+//! ┌─────────────────┐ ┌─────────────┐ ┌─────────────────┐
+//! │     Indexer     │ │   Parser    │ │    Database     │
+//! │  (Parallel file │ │ (tree-sitter│ │   (SQLite       │
+//! │   processing)   │ │   AST)      │ │    storage)     │
+//! └─────────────────┘ └─────────────┘ └─────────────────┘
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use codi::symbol_index::{SymbolIndexService, SymbolIndexServiceBuilder};
+//!
+//! // Create service with defaults
+//! let service = SymbolIndexService::new("/path/to/project").await?;
+//!
+//! // Or use the builder for custom configuration
+//! let service = SymbolIndexServiceBuilder::new("/path/to/project")
+//!     .include(&["**/*.rs", "**/*.py"])
+//!     .exclude(&["**/test/**"])
+//!     .parallel_jobs(4)
+//!     .build()
+//!     .await?;
+//!
+//! // Build the index
+//! let result = service.build(false).await?;
+//! println!("Indexed {} files with {} symbols", result.files_indexed, result.total_symbols);
+//!
+//! // Find symbols
+//! let symbols = service.find_symbols("Config", None).await?;
+//! for symbol in symbols {
+//!     println!("{}:{} - {} ({})", symbol.file, symbol.line, symbol.name, symbol.kind);
+//! }
+//!
+//! // Get statistics
+//! let stats = service.get_stats().await?;
+//! println!("Index contains {} files and {} symbols", stats.total_files, stats.total_symbols);
+//! ```
+//!
+//! # Telemetry
+//!
+//! All operations record telemetry metrics when the `telemetry` feature is enabled:
+//!
+//! - `symbol_index.service.*` - Service-level operations
+//! - `symbol_index.indexer.*` - Indexing operations
+//! - `symbol_index.parser.*` - Parsing operations
+//! - `symbol_index.db.*` - Database operations
+
+pub mod database;
+pub mod indexer;
+pub mod parser;
+pub mod service;
+pub mod types;
+
+// Re-export commonly used types
+pub use database::{SymbolDatabase, INDEX_VERSION};
+pub use indexer::{FileWatcher, IndexProgress, IndexResult, Indexer, ProgressCallback};
+pub use parser::{ParseResult, SymbolParser};
+pub use service::{SymbolIndexService, SymbolIndexServiceBuilder};
+pub use types::{
+    CodeSymbol, DependencyDirection, DependencyResult, DependencyType, ExtractionMethod,
+    ImportStatement, ImportedSymbol, IndexBuildOptions, IndexStats, IndexedFile, IndexedSymbol,
+    Language, ReferenceResult, ReferenceType, SymbolKind, SymbolSearchResult, SymbolVisibility,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_full_workflow() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        // Create some test files
+        fs::create_dir(project_root.join("src")).unwrap();
+
+        fs::write(
+            project_root.join("src/main.ts"),
+            r#"
+import { Config } from './config';
+
+export function main() {
+    const config = new Config();
+    console.log(config.toString());
+}
+
+export class App {
+    private config: Config;
+
+    constructor() {
+        this.config = new Config();
+    }
+
+    run(): void {
+        main();
+    }
+}
+"#,
+        )
+        .unwrap();
+
+        fs::write(
+            project_root.join("src/config.ts"),
+            r#"
+export interface ConfigOptions {
+    name: string;
+    debug: boolean;
+}
+
+export class Config {
+    private options: ConfigOptions;
+
+    constructor(options?: Partial<ConfigOptions>) {
+        this.options = {
+            name: 'default',
+            debug: false,
+            ...options,
+        };
+    }
+
+    toString(): string {
+        return JSON.stringify(this.options);
+    }
+}
+
+export const DEFAULT_CONFIG: ConfigOptions = {
+    name: 'default',
+    debug: false,
+};
+"#,
+        )
+        .unwrap();
+
+        // Create service and build index
+        let service = SymbolIndexService::new(project_root.to_str().unwrap())
+            .await
+            .unwrap();
+
+        let result = service.build(false).await.unwrap();
+
+        // Verify indexing results
+        assert_eq!(result.files_indexed, 2);
+        assert!(result.total_symbols >= 6); // main, App, Config, ConfigOptions, toString, DEFAULT_CONFIG
+        assert!(result.total_imports >= 1); // import from ./config
+
+        // Test symbol search
+        let configs = service.find_symbols("Config", None).await.unwrap();
+        assert!(!configs.is_empty());
+        assert!(configs.iter().any(|s| s.name == "Config"));
+
+        // Test find by kind
+        let classes = service
+            .find_symbols_by_kind(SymbolKind::Class, None)
+            .await
+            .unwrap();
+        assert!(!classes.is_empty());
+
+        // Test get definition
+        let def = service.get_definition("App").await.unwrap();
+        assert!(def.is_some());
+        assert_eq!(def.unwrap().kind, SymbolKind::Class);
+
+        // Test stats
+        let stats = service.get_stats().await.unwrap();
+        assert_eq!(stats.total_files, 2);
+        assert!(stats.total_symbols >= 6);
+
+        // Test incremental update - modify a file
+        fs::write(
+            project_root.join("src/main.ts"),
+            r#"
+import { Config } from './config';
+
+export function main() {
+    console.log('Hello');
+}
+
+export function newFunction() {
+    return 42;
+}
+"#,
+        )
+        .unwrap();
+
+        let result2 = service.build(false).await.unwrap();
+        assert_eq!(result2.files_indexed, 1); // Only main.ts changed
+        assert_eq!(result2.files_skipped, 1); // config.ts unchanged
+
+        // Verify new function is indexed
+        let new_fn = service.find_symbols("newFunction", None).await.unwrap();
+        assert_eq!(new_fn.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_multi_language() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        // Create files in different languages
+        fs::write(project_root.join("main.ts"), "export function ts_func() {}").unwrap();
+        fs::write(project_root.join("lib.rs"), "pub fn rust_func() {}").unwrap();
+        fs::write(project_root.join("utils.py"), "def python_func():\n    pass").unwrap();
+        fs::write(project_root.join("helper.go"), "package main\nfunc GoFunc() {}").unwrap();
+
+        let service = SymbolIndexService::new(project_root.to_str().unwrap())
+            .await
+            .unwrap();
+
+        let result = service.build(false).await.unwrap();
+
+        // All files should be indexed
+        assert_eq!(result.files_indexed, 4);
+
+        // Each function should be findable
+        let ts = service.find_symbols("ts_func", None).await.unwrap();
+        assert_eq!(ts.len(), 1);
+
+        let rust = service.find_symbols("rust_func", None).await.unwrap();
+        assert_eq!(rust.len(), 1);
+
+        let python = service.find_symbols("python_func", None).await.unwrap();
+        assert_eq!(python.len(), 1);
+
+        let go = service.find_symbols("GoFunc", None).await.unwrap();
+        assert_eq!(go.len(), 1);
+    }
+}

--- a/codi-rs/src/symbol_index/parser.rs
+++ b/codi-rs/src/symbol_index/parser.rs
@@ -1,0 +1,1366 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Tree-sitter based symbol extraction.
+//!
+//! Parses source files using tree-sitter grammars to extract symbols,
+//! imports, and structure information.
+
+use std::path::Path;
+use std::time::Instant;
+
+use sha2::{Digest, Sha256};
+use tree_sitter::{Parser, Node};
+
+use crate::error::ToolError;
+
+#[cfg(feature = "telemetry")]
+use crate::telemetry::metrics::GLOBAL_METRICS;
+
+use super::types::{
+    CodeSymbol, ExtractionMethod, ImportStatement, ImportedSymbol,
+    Language as LangType, SymbolKind, SymbolVisibility,
+};
+
+/// Result of parsing a source file.
+#[derive(Debug, Clone)]
+pub struct ParseResult {
+    /// Content hash for change detection.
+    pub hash: String,
+    /// Extraction method used.
+    pub method: ExtractionMethod,
+    /// Extracted symbols.
+    pub symbols: Vec<CodeSymbol>,
+    /// Extracted imports.
+    pub imports: Vec<ImportStatement>,
+}
+
+/// Symbol parser using tree-sitter.
+pub struct SymbolParser {
+    parsers: std::collections::HashMap<LangType, Parser>,
+}
+
+impl SymbolParser {
+    /// Create a new symbol parser with all supported languages.
+    pub fn new() -> Result<Self, ToolError> {
+        let start = Instant::now();
+
+        let mut parsers = std::collections::HashMap::new();
+
+        // Initialize parsers for each language
+        let languages = [
+            (LangType::TypeScript, tree_sitter_typescript::LANGUAGE_TYPESCRIPT),
+            (LangType::JavaScript, tree_sitter_javascript::LANGUAGE),
+            (LangType::Rust, tree_sitter_rust::LANGUAGE),
+            (LangType::Python, tree_sitter_python::LANGUAGE),
+            (LangType::Go, tree_sitter_go::LANGUAGE),
+        ];
+
+        for (lang_type, lang) in languages {
+            let mut parser = Parser::new();
+            parser.set_language(&lang.into()).map_err(|e| {
+                ToolError::ExecutionFailed(format!(
+                    "Failed to set {:?} language: {}",
+                    lang_type, e
+                ))
+            })?;
+            parsers.insert(lang_type, parser);
+        }
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.new", start.elapsed());
+
+        Ok(Self { parsers })
+    }
+
+    /// Parse a source file and extract symbols.
+    pub fn parse_file(&mut self, path: &Path, content: &str) -> Result<ParseResult, ToolError> {
+        let start = Instant::now();
+
+        // Calculate content hash
+        let hash = {
+            let mut hasher = Sha256::new();
+            hasher.update(content.as_bytes());
+            format!("{:x}", hasher.finalize())
+        };
+
+        // Detect language
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+        let lang = LangType::from_extension(ext);
+
+        let result = if let Some(parser) = self.parsers.get_mut(&lang) {
+            // Parse with tree-sitter
+            let tree = parser.parse(content, None).ok_or_else(|| {
+                ToolError::ExecutionFailed(format!("Failed to parse file: {}", path.display()))
+            })?;
+
+            let symbols = self.extract_symbols(&tree.root_node(), content, lang)?;
+            let imports = self.extract_imports(&tree.root_node(), content, lang)?;
+
+            ParseResult {
+                hash,
+                method: ExtractionMethod::TreeSitter,
+                symbols,
+                imports,
+            }
+        } else {
+            // Fallback to regex-based extraction for unknown languages
+            let symbols = self.extract_symbols_regex(content)?;
+
+            ParseResult {
+                hash,
+                method: ExtractionMethod::Regex,
+                symbols,
+                imports: Vec::new(),
+            }
+        };
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.parse_file", start.elapsed());
+
+        Ok(result)
+    }
+
+    /// Extract symbols from a parsed tree.
+    fn extract_symbols(
+        &self,
+        root: &Node,
+        source: &str,
+        lang: LangType,
+    ) -> Result<Vec<CodeSymbol>, ToolError> {
+        let start = Instant::now();
+
+        let symbols = match lang {
+            LangType::TypeScript | LangType::JavaScript => {
+                self.extract_ts_symbols(root, source)?
+            }
+            LangType::Rust => self.extract_rust_symbols(root, source)?,
+            LangType::Python => self.extract_python_symbols(root, source)?,
+            LangType::Go => self.extract_go_symbols(root, source)?,
+            _ => Vec::new(),
+        };
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.extract_symbols", start.elapsed());
+
+        Ok(symbols)
+    }
+
+    /// Extract TypeScript/JavaScript symbols.
+    fn extract_ts_symbols(&self, root: &Node, source: &str) -> Result<Vec<CodeSymbol>, ToolError> {
+        let start = Instant::now();
+        let mut symbols = Vec::new();
+        let source_bytes = source.as_bytes();
+
+        self.walk_tree(root, &mut |node| {
+            let kind = node.kind();
+
+            match kind {
+                "function_declaration" | "method_definition" | "arrow_function" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: if kind == "method_definition" {
+                                SymbolKind::Method
+                            } else {
+                                SymbolKind::Function
+                            },
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: self.get_ts_visibility(node, source_bytes),
+                            signature: self.get_node_text(node, source_bytes),
+                            doc_summary: self.get_preceding_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "class_declaration" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::Class,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: self.get_ts_visibility(node, source_bytes),
+                            signature: self.get_signature_line(node, source_bytes),
+                            doc_summary: self.get_preceding_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "interface_declaration" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::Interface,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: SymbolVisibility::Public,
+                            signature: self.get_signature_line(node, source_bytes),
+                            doc_summary: self.get_preceding_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "type_alias_declaration" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::TypeAlias,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: SymbolVisibility::Public,
+                            signature: self.get_node_text(node, source_bytes),
+                            doc_summary: self.get_preceding_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "enum_declaration" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::Enum,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: SymbolVisibility::Public,
+                            signature: self.get_signature_line(node, source_bytes),
+                            doc_summary: self.get_preceding_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "variable_declaration" | "lexical_declaration" => {
+                    // Handle const/let/var declarations
+                    for i in 0..node.child_count() {
+                        if let Some(child) = node.child(i) {
+                            if child.kind() == "variable_declarator" {
+                                if let Some(name) = self.get_child_by_field(&child, "name", source_bytes) {
+                                    symbols.push(CodeSymbol {
+                                        name,
+                                        kind: SymbolKind::Variable,
+                                        line: node.start_position().row as u32 + 1,
+                                        end_line: Some(node.end_position().row as u32 + 1),
+                                        column: node.start_position().column as u32,
+                                        visibility: SymbolVisibility::Unknown,
+                                        signature: self.get_node_text(node, source_bytes),
+                                        doc_summary: None,
+                                        metadata: None,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        });
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.extract_ts_symbols", start.elapsed());
+
+        Ok(symbols)
+    }
+
+    /// Extract Rust symbols.
+    fn extract_rust_symbols(&self, root: &Node, source: &str) -> Result<Vec<CodeSymbol>, ToolError> {
+        let start = Instant::now();
+        let mut symbols = Vec::new();
+        let source_bytes = source.as_bytes();
+
+        self.walk_tree(root, &mut |node| {
+            let kind = node.kind();
+
+            match kind {
+                "function_item" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::Function,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: self.get_rust_visibility(node, source_bytes),
+                            signature: self.get_rust_signature(node, source_bytes),
+                            doc_summary: self.get_rust_doc_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "struct_item" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::Struct,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: self.get_rust_visibility(node, source_bytes),
+                            signature: self.get_signature_line(node, source_bytes),
+                            doc_summary: self.get_rust_doc_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "enum_item" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::Enum,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: self.get_rust_visibility(node, source_bytes),
+                            signature: self.get_signature_line(node, source_bytes),
+                            doc_summary: self.get_rust_doc_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "trait_item" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::Trait,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: self.get_rust_visibility(node, source_bytes),
+                            signature: self.get_signature_line(node, source_bytes),
+                            doc_summary: self.get_rust_doc_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "impl_item" => {
+                    if let Some(type_node) = node.child_by_field_name("type") {
+                        let name = self.node_text(&type_node, source_bytes);
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::Impl,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: SymbolVisibility::Unknown,
+                            signature: self.get_signature_line(node, source_bytes),
+                            doc_summary: None,
+                            metadata: None,
+                        });
+                    }
+                }
+                "mod_item" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::Module,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: self.get_rust_visibility(node, source_bytes),
+                            signature: None,
+                            doc_summary: self.get_rust_doc_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "const_item" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::Constant,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: self.get_rust_visibility(node, source_bytes),
+                            signature: self.get_node_text(node, source_bytes),
+                            doc_summary: self.get_rust_doc_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "type_item" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::TypeAlias,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: self.get_rust_visibility(node, source_bytes),
+                            signature: self.get_node_text(node, source_bytes),
+                            doc_summary: self.get_rust_doc_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "macro_definition" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name,
+                            kind: SymbolKind::Macro,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: SymbolVisibility::Unknown,
+                            signature: None,
+                            doc_summary: self.get_rust_doc_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        });
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.extract_rust_symbols", start.elapsed());
+
+        Ok(symbols)
+    }
+
+    /// Extract Python symbols.
+    fn extract_python_symbols(&self, root: &Node, source: &str) -> Result<Vec<CodeSymbol>, ToolError> {
+        let start = Instant::now();
+        let mut symbols = Vec::new();
+        let source_bytes = source.as_bytes();
+
+        self.walk_tree(root, &mut |node| {
+            let kind = node.kind();
+
+            match kind {
+                "function_definition" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        let is_method = node.parent()
+                            .map(|p| p.kind() == "class_definition")
+                            .unwrap_or(false);
+
+                        symbols.push(CodeSymbol {
+                            name: name.clone(),
+                            kind: if is_method { SymbolKind::Method } else { SymbolKind::Function },
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: if name.starts_with("_") && !name.starts_with("__") {
+                                SymbolVisibility::Private
+                            } else {
+                                SymbolVisibility::Public
+                            },
+                            signature: self.get_python_signature(node, source_bytes),
+                            doc_summary: self.get_python_docstring(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "class_definition" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name: name.clone(),
+                            kind: SymbolKind::Class,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: if name.starts_with("_") {
+                                SymbolVisibility::Private
+                            } else {
+                                SymbolVisibility::Public
+                            },
+                            signature: self.get_signature_line(node, source_bytes),
+                            doc_summary: self.get_python_docstring(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        });
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.extract_python_symbols", start.elapsed());
+
+        Ok(symbols)
+    }
+
+    /// Extract Go symbols.
+    fn extract_go_symbols(&self, root: &Node, source: &str) -> Result<Vec<CodeSymbol>, ToolError> {
+        let start = Instant::now();
+        let mut symbols = Vec::new();
+        let source_bytes = source.as_bytes();
+
+        self.walk_tree(root, &mut |node| {
+            let kind = node.kind();
+
+            match kind {
+                "function_declaration" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name: name.clone(),
+                            kind: SymbolKind::Function,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: if name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+                                SymbolVisibility::Public
+                            } else {
+                                SymbolVisibility::Private
+                            },
+                            signature: self.get_go_signature(node, source_bytes),
+                            doc_summary: self.get_preceding_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "method_declaration" => {
+                    if let Some(name) = self.get_child_by_field(node, "name", source_bytes) {
+                        symbols.push(CodeSymbol {
+                            name: name.clone(),
+                            kind: SymbolKind::Method,
+                            line: node.start_position().row as u32 + 1,
+                            end_line: Some(node.end_position().row as u32 + 1),
+                            column: node.start_position().column as u32,
+                            visibility: if name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+                                SymbolVisibility::Public
+                            } else {
+                                SymbolVisibility::Private
+                            },
+                            signature: self.get_go_signature(node, source_bytes),
+                            doc_summary: self.get_preceding_comment(node, source_bytes),
+                            metadata: None,
+                        });
+                    }
+                }
+                "type_declaration" => {
+                    for i in 0..node.child_count() {
+                        if let Some(spec) = node.child(i) {
+                            if spec.kind() == "type_spec" {
+                                if let Some(name) = self.get_child_by_field(&spec, "name", source_bytes) {
+                                    let type_kind = spec.child_by_field_name("type")
+                                        .map(|t| t.kind())
+                                        .unwrap_or("");
+
+                                    let symbol_kind = match type_kind {
+                                        "struct_type" => SymbolKind::Struct,
+                                        "interface_type" => SymbolKind::Interface,
+                                        _ => SymbolKind::TypeAlias,
+                                    };
+
+                                    symbols.push(CodeSymbol {
+                                        name: name.clone(),
+                                        kind: symbol_kind,
+                                        line: spec.start_position().row as u32 + 1,
+                                        end_line: Some(spec.end_position().row as u32 + 1),
+                                        column: spec.start_position().column as u32,
+                                        visibility: if name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+                                            SymbolVisibility::Public
+                                        } else {
+                                            SymbolVisibility::Private
+                                        },
+                                        signature: self.get_signature_line(&spec, source_bytes),
+                                        doc_summary: self.get_preceding_comment(node, source_bytes),
+                                        metadata: None,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+                "const_declaration" | "var_declaration" => {
+                    for i in 0..node.child_count() {
+                        if let Some(spec) = node.child(i) {
+                            if spec.kind() == "const_spec" || spec.kind() == "var_spec" {
+                                if let Some(name_node) = spec.child_by_field_name("name") {
+                                    let name = self.node_text(&name_node, source_bytes);
+                                    symbols.push(CodeSymbol {
+                                        name: name.clone(),
+                                        kind: if kind == "const_declaration" {
+                                            SymbolKind::Constant
+                                        } else {
+                                            SymbolKind::Variable
+                                        },
+                                        line: spec.start_position().row as u32 + 1,
+                                        end_line: Some(spec.end_position().row as u32 + 1),
+                                        column: spec.start_position().column as u32,
+                                        visibility: if name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+                                            SymbolVisibility::Public
+                                        } else {
+                                            SymbolVisibility::Private
+                                        },
+                                        signature: self.get_node_text(&spec, source_bytes),
+                                        doc_summary: None,
+                                        metadata: None,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        });
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.extract_go_symbols", start.elapsed());
+
+        Ok(symbols)
+    }
+
+    /// Extract imports from a parsed tree.
+    fn extract_imports(
+        &self,
+        root: &Node,
+        source: &str,
+        lang: LangType,
+    ) -> Result<Vec<ImportStatement>, ToolError> {
+        let start = Instant::now();
+
+        let imports = match lang {
+            LangType::TypeScript | LangType::JavaScript => {
+                self.extract_ts_imports(root, source)?
+            }
+            LangType::Rust => self.extract_rust_imports(root, source)?,
+            LangType::Python => self.extract_python_imports(root, source)?,
+            LangType::Go => self.extract_go_imports(root, source)?,
+            _ => Vec::new(),
+        };
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.extract_imports", start.elapsed());
+
+        Ok(imports)
+    }
+
+    /// Extract TypeScript/JavaScript imports.
+    fn extract_ts_imports(&self, root: &Node, source: &str) -> Result<Vec<ImportStatement>, ToolError> {
+        let start = Instant::now();
+        let mut imports = Vec::new();
+        let source_bytes = source.as_bytes();
+
+        self.walk_tree(root, &mut |node| {
+            if node.kind() == "import_statement" {
+                let line = node.start_position().row as u32 + 1;
+
+                // Get source module
+                let source_path = node.child_by_field_name("source")
+                    .map(|n| self.node_text(&n, source_bytes).trim_matches('"').trim_matches('\'').to_string())
+                    .unwrap_or_default();
+
+                // Check if type-only import
+                let is_type_only = node.children(&mut node.walk())
+                    .any(|c| c.kind() == "type");
+
+                let mut symbols = Vec::new();
+
+                // Handle import clause
+                if let Some(clause) = node.child_by_field_name("import") {
+                    // Default import
+                    if clause.kind() == "identifier" {
+                        symbols.push(ImportedSymbol {
+                            name: self.node_text(&clause, source_bytes),
+                            alias: None,
+                            is_default: true,
+                            is_namespace: false,
+                        });
+                    }
+
+                    // Named imports
+                    self.walk_tree(&clause, &mut |child| {
+                        match child.kind() {
+                            "import_specifier" => {
+                                let name = child.child_by_field_name("name")
+                                    .map(|n| self.node_text(&n, source_bytes))
+                                    .unwrap_or_default();
+                                let alias = child.child_by_field_name("alias")
+                                    .map(|n| self.node_text(&n, source_bytes));
+
+                                symbols.push(ImportedSymbol {
+                                    name,
+                                    alias,
+                                    is_default: false,
+                                    is_namespace: false,
+                                });
+                            }
+                            "namespace_import" => {
+                                if let Some(alias_node) = child.child_by_field_name("alias") {
+                                    symbols.push(ImportedSymbol {
+                                        name: "*".to_string(),
+                                        alias: Some(self.node_text(&alias_node, source_bytes)),
+                                        is_default: false,
+                                        is_namespace: true,
+                                    });
+                                }
+                            }
+                            _ => {}
+                        }
+                    });
+                }
+
+                if !source_path.is_empty() {
+                    imports.push(ImportStatement {
+                        source: source_path,
+                        line,
+                        is_type_only,
+                        symbols,
+                    });
+                }
+            }
+        });
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.extract_ts_imports", start.elapsed());
+
+        Ok(imports)
+    }
+
+    /// Extract Rust imports (use statements).
+    fn extract_rust_imports(&self, root: &Node, source: &str) -> Result<Vec<ImportStatement>, ToolError> {
+        let start = Instant::now();
+        let mut imports = Vec::new();
+        let source_bytes = source.as_bytes();
+
+        self.walk_tree(root, &mut |node| {
+            if node.kind() == "use_declaration" {
+                let line = node.start_position().row as u32 + 1;
+                let _use_text = self.node_text(node, source_bytes);
+
+                // Extract the path from the use statement
+                if let Some(path_node) = node.child_by_field_name("argument") {
+                    let source_path = self.node_text(&path_node, source_bytes);
+
+                    imports.push(ImportStatement {
+                        source: source_path.clone(),
+                        line,
+                        is_type_only: false,
+                        symbols: vec![ImportedSymbol {
+                            name: source_path,
+                            alias: None,
+                            is_default: false,
+                            is_namespace: false,
+                        }],
+                    });
+                }
+            }
+        });
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.extract_rust_imports", start.elapsed());
+
+        Ok(imports)
+    }
+
+    /// Extract Python imports.
+    fn extract_python_imports(&self, root: &Node, source: &str) -> Result<Vec<ImportStatement>, ToolError> {
+        let start = Instant::now();
+        let mut imports = Vec::new();
+        let source_bytes = source.as_bytes();
+
+        self.walk_tree(root, &mut |node| {
+            match node.kind() {
+                "import_statement" => {
+                    let line = node.start_position().row as u32 + 1;
+
+                    for i in 0..node.child_count() {
+                        if let Some(child) = node.child(i) {
+                            if child.kind() == "dotted_name" {
+                                let module = self.node_text(&child, source_bytes);
+                                imports.push(ImportStatement {
+                                    source: module.clone(),
+                                    line,
+                                    is_type_only: false,
+                                    symbols: vec![ImportedSymbol {
+                                        name: module,
+                                        alias: None,
+                                        is_default: false,
+                                        is_namespace: true,
+                                    }],
+                                });
+                            }
+                        }
+                    }
+                }
+                "import_from_statement" => {
+                    let line = node.start_position().row as u32 + 1;
+
+                    let module = node.child_by_field_name("module_name")
+                        .map(|n| self.node_text(&n, source_bytes))
+                        .unwrap_or_default();
+
+                    let mut symbols = Vec::new();
+
+                    for i in 0..node.child_count() {
+                        if let Some(child) = node.child(i) {
+                            if child.kind() == "aliased_import" {
+                                let name = child.child_by_field_name("name")
+                                    .map(|n| self.node_text(&n, source_bytes))
+                                    .unwrap_or_default();
+                                let alias = child.child_by_field_name("alias")
+                                    .map(|n| self.node_text(&n, source_bytes));
+
+                                symbols.push(ImportedSymbol {
+                                    name,
+                                    alias,
+                                    is_default: false,
+                                    is_namespace: false,
+                                });
+                            } else if child.kind() == "dotted_name" && i > 1 {
+                                symbols.push(ImportedSymbol {
+                                    name: self.node_text(&child, source_bytes),
+                                    alias: None,
+                                    is_default: false,
+                                    is_namespace: false,
+                                });
+                            }
+                        }
+                    }
+
+                    if !module.is_empty() {
+                        imports.push(ImportStatement {
+                            source: module,
+                            line,
+                            is_type_only: false,
+                            symbols,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        });
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.extract_python_imports", start.elapsed());
+
+        Ok(imports)
+    }
+
+    /// Extract Go imports.
+    fn extract_go_imports(&self, root: &Node, source: &str) -> Result<Vec<ImportStatement>, ToolError> {
+        let start = Instant::now();
+        let mut imports = Vec::new();
+        let source_bytes = source.as_bytes();
+
+        self.walk_tree(root, &mut |node| {
+            if node.kind() == "import_declaration" {
+                for i in 0..node.child_count() {
+                    if let Some(child) = node.child(i) {
+                        if child.kind() == "import_spec" || child.kind() == "import_spec_list" {
+                            self.walk_tree(&child, &mut |spec| {
+                                if spec.kind() == "import_spec" {
+                                    let path = spec.child_by_field_name("path")
+                                        .map(|n| self.node_text(&n, source_bytes).trim_matches('"').to_string())
+                                        .unwrap_or_default();
+
+                                    let alias = spec.child_by_field_name("name")
+                                        .map(|n| self.node_text(&n, source_bytes));
+
+                                    if !path.is_empty() {
+                                        imports.push(ImportStatement {
+                                            source: path.clone(),
+                                            line: spec.start_position().row as u32 + 1,
+                                            is_type_only: false,
+                                            symbols: vec![ImportedSymbol {
+                                                name: path,
+                                                alias,
+                                                is_default: false,
+                                                is_namespace: true,
+                                            }],
+                                        });
+                                    }
+                                }
+                            });
+                        } else if child.kind() == "interpreted_string_literal" {
+                            let path = self.node_text(&child, source_bytes).trim_matches('"').to_string();
+                            if !path.is_empty() {
+                                imports.push(ImportStatement {
+                                    source: path.clone(),
+                                    line: node.start_position().row as u32 + 1,
+                                    is_type_only: false,
+                                    symbols: vec![ImportedSymbol {
+                                        name: path,
+                                        alias: None,
+                                        is_default: false,
+                                        is_namespace: true,
+                                    }],
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.extract_go_imports", start.elapsed());
+
+        Ok(imports)
+    }
+
+    /// Regex-based symbol extraction fallback.
+    fn extract_symbols_regex(&self, content: &str) -> Result<Vec<CodeSymbol>, ToolError> {
+        let start = Instant::now();
+        let mut symbols = Vec::new();
+
+        // Simple regex patterns for common constructs
+        let patterns = [
+            (r"(?m)^(?:export\s+)?(?:async\s+)?function\s+(\w+)", SymbolKind::Function),
+            (r"(?m)^(?:export\s+)?class\s+(\w+)", SymbolKind::Class),
+            (r"(?m)^(?:export\s+)?interface\s+(\w+)", SymbolKind::Interface),
+            (r"(?m)^(?:export\s+)?type\s+(\w+)", SymbolKind::TypeAlias),
+            (r"(?m)^(?:export\s+)?enum\s+(\w+)", SymbolKind::Enum),
+            (r"(?m)^(?:pub\s+)?fn\s+(\w+)", SymbolKind::Function),
+            (r"(?m)^(?:pub\s+)?struct\s+(\w+)", SymbolKind::Struct),
+            (r"(?m)^(?:pub\s+)?enum\s+(\w+)", SymbolKind::Enum),
+            (r"(?m)^(?:pub\s+)?trait\s+(\w+)", SymbolKind::Trait),
+            (r"(?m)^def\s+(\w+)", SymbolKind::Function),
+            (r"(?m)^class\s+(\w+)", SymbolKind::Class),
+            (r"(?m)^func\s+(\w+)", SymbolKind::Function),
+            (r"(?m)^type\s+(\w+)\s+struct", SymbolKind::Struct),
+        ];
+
+        for (pattern, kind) in patterns {
+            if let Ok(re) = regex::Regex::new(pattern) {
+                for (line_num, line) in content.lines().enumerate() {
+                    if let Some(caps) = re.captures(line) {
+                        if let Some(name) = caps.get(1) {
+                            symbols.push(CodeSymbol {
+                                name: name.as_str().to_string(),
+                                kind,
+                                line: line_num as u32 + 1,
+                                end_line: None,
+                                column: 0,
+                                visibility: SymbolVisibility::Unknown,
+                                signature: Some(line.trim().to_string()),
+                                doc_summary: None,
+                                metadata: None,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.parser.extract_symbols_regex", start.elapsed());
+
+        Ok(symbols)
+    }
+
+    // Helper methods
+
+    /// Walk the tree depth-first, calling the callback for each node.
+    fn walk_tree<F>(&self, node: &Node, callback: &mut F)
+    where
+        F: FnMut(&Node),
+    {
+        callback(node);
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i) {
+                self.walk_tree(&child, callback);
+            }
+        }
+    }
+
+    /// Get text content of a node.
+    fn node_text(&self, node: &Node, source: &[u8]) -> String {
+        node.utf8_text(source).unwrap_or("").to_string()
+    }
+
+    /// Get a child node by field name and return its text.
+    fn get_child_by_field(&self, node: &Node, field: &str, source: &[u8]) -> Option<String> {
+        node.child_by_field_name(field)
+            .map(|n| self.node_text(&n, source))
+    }
+
+    /// Get the full text of a node (for signatures).
+    fn get_node_text(&self, node: &Node, source: &[u8]) -> Option<String> {
+        let text = self.node_text(node, source);
+        if text.len() > 200 {
+            Some(format!("{}...", &text[..197]))
+        } else {
+            Some(text)
+        }
+    }
+
+    /// Get just the first line of a node (for type signatures).
+    fn get_signature_line(&self, node: &Node, source: &[u8]) -> Option<String> {
+        let text = self.node_text(node, source);
+        text.lines().next().map(|s| s.to_string())
+    }
+
+    /// Get TypeScript/JavaScript visibility.
+    fn get_ts_visibility(&self, node: &Node, source: &[u8]) -> SymbolVisibility {
+        // Check for export keyword
+        if let Some(parent) = node.parent() {
+            for i in 0..parent.child_count() {
+                if let Some(child) = parent.child(i) {
+                    let text = self.node_text(&child, source);
+                    if text == "export" {
+                        return SymbolVisibility::Public;
+                    }
+                }
+            }
+        }
+
+        // Check for modifiers on the node itself
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i) {
+                let text = self.node_text(&child, source);
+                match text.as_str() {
+                    "public" | "export" => return SymbolVisibility::Public,
+                    "private" => return SymbolVisibility::Private,
+                    "protected" => return SymbolVisibility::Protected,
+                    _ => {}
+                }
+            }
+        }
+
+        SymbolVisibility::Unknown
+    }
+
+    /// Get Rust visibility.
+    fn get_rust_visibility(&self, node: &Node, source: &[u8]) -> SymbolVisibility {
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i) {
+                if child.kind() == "visibility_modifier" {
+                    let text = self.node_text(&child, source);
+                    if text.contains("pub(crate)") {
+                        return SymbolVisibility::Internal;
+                    } else if text.starts_with("pub") {
+                        return SymbolVisibility::Public;
+                    }
+                }
+            }
+        }
+        SymbolVisibility::Private
+    }
+
+    /// Get Rust function signature.
+    fn get_rust_signature(&self, node: &Node, source: &[u8]) -> Option<String> {
+        // Find the function body and exclude it
+        let text = self.node_text(node, source);
+        if let Some(pos) = text.find('{') {
+            Some(text[..pos].trim().to_string())
+        } else {
+            Some(text)
+        }
+    }
+
+    /// Get Rust doc comment.
+    fn get_rust_doc_comment(&self, node: &Node, source: &[u8]) -> Option<String> {
+        // Look for preceding doc comments
+        if let Some(parent) = node.parent() {
+            let mut prev_sibling = None;
+            for i in 0..parent.child_count() {
+                if let Some(child) = parent.child(i) {
+                    if child.id() == node.id() {
+                        break;
+                    }
+                    prev_sibling = Some(child);
+                }
+            }
+
+            if let Some(prev) = prev_sibling {
+                let text = self.node_text(&prev, source);
+                if text.starts_with("///") || text.starts_with("//!") {
+                    let lines: Vec<&str> = text
+                        .lines()
+                        .map(|l| l.trim_start_matches('/').trim())
+                        .take(3)
+                        .collect();
+                    return Some(lines.join(" "));
+                }
+            }
+        }
+        None
+    }
+
+    /// Get Python function signature.
+    fn get_python_signature(&self, node: &Node, source: &[u8]) -> Option<String> {
+        // Get the def line including parameters
+        let text = self.node_text(node, source);
+        if let Some(pos) = text.find(':') {
+            Some(text[..pos].trim().to_string())
+        } else {
+            Some(text.lines().next().unwrap_or("").to_string())
+        }
+    }
+
+    /// Get Python docstring.
+    fn get_python_docstring(&self, node: &Node, source: &[u8]) -> Option<String> {
+        // Look for string expression as first statement in body
+        if let Some(body) = node.child_by_field_name("body") {
+            for i in 0..body.child_count() {
+                if let Some(child) = body.child(i) {
+                    if child.kind() == "expression_statement" {
+                        if let Some(expr) = child.child(0) {
+                            if expr.kind() == "string" {
+                                let text = self.node_text(&expr, source);
+                                let trimmed = text.trim_matches('"').trim_matches('\'').trim();
+                                let first_line = trimmed.lines().next().unwrap_or(trimmed);
+                                return Some(first_line.to_string());
+                            }
+                        }
+                    }
+                    break; // Only check first statement
+                }
+            }
+        }
+        None
+    }
+
+    /// Get Go function signature.
+    fn get_go_signature(&self, node: &Node, source: &[u8]) -> Option<String> {
+        let text = self.node_text(node, source);
+        if let Some(pos) = text.find('{') {
+            Some(text[..pos].trim().to_string())
+        } else {
+            Some(text.lines().next().unwrap_or("").to_string())
+        }
+    }
+
+    /// Get preceding comment for documentation.
+    fn get_preceding_comment(&self, node: &Node, source: &[u8]) -> Option<String> {
+        if let Some(parent) = node.parent() {
+            let mut prev_sibling = None;
+            for i in 0..parent.child_count() {
+                if let Some(child) = parent.child(i) {
+                    if child.id() == node.id() {
+                        break;
+                    }
+                    if child.kind().contains("comment") {
+                        prev_sibling = Some(child);
+                    }
+                }
+            }
+
+            if let Some(prev) = prev_sibling {
+                let text = self.node_text(&prev, source);
+                let cleaned: String = text
+                    .lines()
+                    .map(|l| l.trim_start_matches('/').trim_start_matches('*').trim())
+                    .filter(|l| !l.is_empty())
+                    .take(3)
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                if !cleaned.is_empty() {
+                    return Some(cleaned);
+                }
+            }
+        }
+        None
+    }
+}
+
+impl Default for SymbolParser {
+    fn default() -> Self {
+        Self::new().expect("Failed to create SymbolParser")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_parser_new() {
+        let parser = SymbolParser::new();
+        assert!(parser.is_ok());
+    }
+
+    #[test]
+    fn test_parse_typescript() {
+        let mut parser = SymbolParser::new().unwrap();
+        let path = PathBuf::from("test.ts");
+        let content = r#"
+export function hello(name: string): string {
+    return `Hello, ${name}!`;
+}
+
+export class Greeter {
+    private name: string;
+
+    constructor(name: string) {
+        this.name = name;
+    }
+
+    greet(): string {
+        return hello(this.name);
+    }
+}
+
+export interface Greeting {
+    message: string;
+}
+
+export type GreetingType = "formal" | "casual";
+"#;
+
+        let result = parser.parse_file(&path, content).unwrap();
+        assert_eq!(result.method, ExtractionMethod::TreeSitter);
+
+        // Check symbols
+        let names: Vec<&str> = result.symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"hello"));
+        assert!(names.contains(&"Greeter"));
+        assert!(names.contains(&"Greeting"));
+        assert!(names.contains(&"GreetingType"));
+    }
+
+    #[test]
+    fn test_parse_rust() {
+        let mut parser = SymbolParser::new().unwrap();
+        let path = PathBuf::from("test.rs");
+        let content = r#"
+/// A greeting function.
+pub fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)
+}
+
+pub struct Config {
+    pub name: String,
+    value: i32,
+}
+
+pub enum Status {
+    Active,
+    Inactive,
+}
+
+pub trait Greetable {
+    fn greet(&self) -> String;
+}
+
+impl Greetable for Config {
+    fn greet(&self) -> String {
+        greet(&self.name)
+    }
+}
+"#;
+
+        let result = parser.parse_file(&path, content).unwrap();
+        assert_eq!(result.method, ExtractionMethod::TreeSitter);
+
+        let names: Vec<&str> = result.symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"greet"));
+        assert!(names.contains(&"Config"));
+        assert!(names.contains(&"Status"));
+        assert!(names.contains(&"Greetable"));
+    }
+
+    #[test]
+    fn test_parse_python() {
+        let mut parser = SymbolParser::new().unwrap();
+        let path = PathBuf::from("test.py");
+        let content = r#"
+def greet(name: str) -> str:
+    """Greet someone by name."""
+    return f"Hello, {name}!"
+
+class Greeter:
+    """A greeter class."""
+
+    def __init__(self, name: str):
+        self._name = name
+
+    def greet(self) -> str:
+        return greet(self._name)
+
+    def _private_method(self):
+        pass
+"#;
+
+        let result = parser.parse_file(&path, content).unwrap();
+        assert_eq!(result.method, ExtractionMethod::TreeSitter);
+
+        let names: Vec<&str> = result.symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"greet"));
+        assert!(names.contains(&"Greeter"));
+    }
+
+    #[test]
+    fn test_parse_go() {
+        let mut parser = SymbolParser::new().unwrap();
+        let path = PathBuf::from("test.go");
+        let content = r#"
+package main
+
+import "fmt"
+
+// Greet greets someone.
+func Greet(name string) string {
+    return fmt.Sprintf("Hello, %s!", name)
+}
+
+type Config struct {
+    Name string
+    value int
+}
+
+type Greeter interface {
+    Greet() string
+}
+
+func (c *Config) Greet() string {
+    return Greet(c.Name)
+}
+"#;
+
+        let result = parser.parse_file(&path, content).unwrap();
+        assert_eq!(result.method, ExtractionMethod::TreeSitter);
+
+        let names: Vec<&str> = result.symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"Greet"));
+        assert!(names.contains(&"Config"));
+        assert!(names.contains(&"Greeter"));
+    }
+
+    #[test]
+    fn test_parse_unknown_language() {
+        let mut parser = SymbolParser::new().unwrap();
+        let path = PathBuf::from("test.xyz");
+        let content = "function hello() {}";
+
+        let result = parser.parse_file(&path, content).unwrap();
+        assert_eq!(result.method, ExtractionMethod::Regex);
+    }
+
+    #[test]
+    fn test_content_hash() {
+        let mut parser = SymbolParser::new().unwrap();
+        let path = PathBuf::from("test.ts");
+
+        let result1 = parser.parse_file(&path, "const a = 1;").unwrap();
+        let result2 = parser.parse_file(&path, "const a = 1;").unwrap();
+        let result3 = parser.parse_file(&path, "const b = 2;").unwrap();
+
+        assert_eq!(result1.hash, result2.hash);
+        assert_ne!(result1.hash, result3.hash);
+    }
+
+    #[test]
+    fn test_ts_imports() {
+        let mut parser = SymbolParser::new().unwrap();
+        let path = PathBuf::from("test.ts");
+        let content = r#"
+import { foo, bar as baz } from './module';
+import * as utils from '../utils';
+import type { Config } from './types';
+import defaultExport from 'package';
+"#;
+
+        let result = parser.parse_file(&path, content).unwrap();
+        assert!(!result.imports.is_empty());
+
+        let sources: Vec<&str> = result.imports.iter().map(|i| i.source.as_str()).collect();
+        assert!(sources.contains(&"./module"));
+        assert!(sources.contains(&"../utils"));
+        assert!(sources.contains(&"./types"));
+        assert!(sources.contains(&"package"));
+    }
+}

--- a/codi-rs/src/symbol_index/service.rs
+++ b/codi-rs/src/symbol_index/service.rs
@@ -1,0 +1,646 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! High-level symbol index service.
+//!
+//! Provides a unified API for building, querying, and maintaining the symbol index.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::sync::Mutex;
+
+use crate::error::ToolError;
+
+#[cfg(feature = "telemetry")]
+use crate::telemetry::metrics::GLOBAL_METRICS;
+
+use super::database::SymbolDatabase;
+use super::indexer::{IndexResult, Indexer, ProgressCallback};
+use super::types::{
+    DependencyDirection, DependencyResult, IndexBuildOptions,
+    IndexStats, ReferenceResult, ReferenceType, SymbolKind, SymbolSearchResult,
+};
+
+/// Symbol index service providing a high-level API.
+pub struct SymbolIndexService {
+    db: Arc<Mutex<SymbolDatabase>>,
+    indexer: Arc<Indexer>,
+    project_root: String,
+}
+
+impl SymbolIndexService {
+    /// Create a new symbol index service.
+    pub async fn new(project_root: &str) -> Result<Self, ToolError> {
+        let start = Instant::now();
+
+        let options = IndexBuildOptions {
+            project_root: project_root.to_string(),
+            ..Default::default()
+        };
+
+        let db = SymbolDatabase::open(project_root)?;
+        let indexer = Indexer::new(options)?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.new", start.elapsed());
+
+        Ok(Self {
+            db: Arc::new(Mutex::new(db)),
+            indexer: Arc::new(indexer),
+            project_root: project_root.to_string(),
+        })
+    }
+
+    /// Create a new symbol index service with custom options.
+    pub async fn with_options(options: IndexBuildOptions) -> Result<Self, ToolError> {
+        let start = Instant::now();
+
+        let db = SymbolDatabase::open(&options.project_root)?;
+        let indexer = Indexer::new(options.clone())?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.with_options", start.elapsed());
+
+        Ok(Self {
+            db: Arc::new(Mutex::new(db)),
+            indexer: Arc::new(indexer),
+            project_root: options.project_root,
+        })
+    }
+
+    /// Get the project root.
+    pub fn project_root(&self) -> &str {
+        &self.project_root
+    }
+
+    /// Build or rebuild the symbol index.
+    pub async fn build(&self, force: bool) -> Result<IndexResult, ToolError> {
+        self.build_with_progress(force, None).await
+    }
+
+    /// Build or rebuild the symbol index with progress callback.
+    pub async fn build_with_progress(
+        &self,
+        force: bool,
+        progress: Option<ProgressCallback>,
+    ) -> Result<IndexResult, ToolError> {
+        let start = Instant::now();
+
+        // Create a new indexer with force_rebuild if needed
+        let options = IndexBuildOptions {
+            project_root: self.project_root.clone(),
+            force_rebuild: force,
+            ..Default::default()
+        };
+
+        let indexer = Indexer::new(options)?;
+        let result = indexer.index_all(self.db.clone(), progress).await?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.build", start.elapsed());
+
+        Ok(result)
+    }
+
+    /// Perform incremental update for specific files.
+    pub async fn update_files(&self, files: &[PathBuf]) -> Result<IndexResult, ToolError> {
+        let start = Instant::now();
+
+        let result = self.indexer.index_files(self.db.clone(), files).await?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.update_files", start.elapsed());
+
+        Ok(result)
+    }
+
+    /// Find symbols by name (fuzzy search).
+    pub async fn find_symbols(
+        &self,
+        query: &str,
+        limit: Option<usize>,
+    ) -> Result<Vec<SymbolSearchResult>, ToolError> {
+        let start = Instant::now();
+
+        let db = self.db.lock().await;
+        let results = db.find_symbols(query, limit.unwrap_or(20))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.find_symbols", start.elapsed());
+
+        Ok(results)
+    }
+
+    /// Find symbols by kind.
+    pub async fn find_symbols_by_kind(
+        &self,
+        kind: SymbolKind,
+        limit: Option<usize>,
+    ) -> Result<Vec<SymbolSearchResult>, ToolError> {
+        let start = Instant::now();
+
+        // Use the kind string as a search prefix
+        let db = self.db.lock().await;
+        let all_results = db.find_symbols("", limit.unwrap_or(1000))?;
+
+        let filtered: Vec<_> = all_results
+            .into_iter()
+            .filter(|s| s.kind == kind)
+            .take(limit.unwrap_or(20))
+            .collect();
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.find_symbols_by_kind", start.elapsed());
+
+        Ok(filtered)
+    }
+
+    /// Find symbols in a specific file.
+    pub async fn find_symbols_in_file(
+        &self,
+        file_path: &str,
+    ) -> Result<Vec<SymbolSearchResult>, ToolError> {
+        let start = Instant::now();
+
+        let db = self.db.lock().await;
+
+        // Search for symbols and filter by file
+        let all_results = db.find_symbols("", 10000)?;
+        let filtered: Vec<_> = all_results
+            .into_iter()
+            .filter(|s| s.file == file_path)
+            .collect();
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.find_symbols_in_file", start.elapsed());
+
+        Ok(filtered)
+    }
+
+    /// Find references to a symbol.
+    pub async fn find_references(
+        &self,
+        symbol_name: &str,
+        include_definition: bool,
+    ) -> Result<Vec<ReferenceResult>, ToolError> {
+        let start = Instant::now();
+
+        let mut results = Vec::new();
+
+        // First find the symbol definition
+        let db = self.db.lock().await;
+        let symbols = db.find_symbols(symbol_name, 1)?;
+
+        if let Some(def_symbol) = symbols.first() {
+            if include_definition {
+                results.push(ReferenceResult {
+                    file: def_symbol.file.clone(),
+                    line: def_symbol.line,
+                    reference_type: ReferenceType::Definition,
+                    context: def_symbol.signature.clone(),
+                });
+            }
+
+            // TODO: Implement usage detection by:
+            // 1. Finding all imports that reference the symbol
+            // 2. Searching for usages in code (would need full text search)
+            // For now, we return just the definition
+        }
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.find_references", start.elapsed());
+
+        Ok(results)
+    }
+
+    /// Get the dependency graph for a file.
+    pub async fn get_dependencies(
+        &self,
+        _file_path: &str,
+        _direction: DependencyDirection,
+        _max_depth: Option<u32>,
+    ) -> Result<Vec<DependencyResult>, ToolError> {
+        let start = Instant::now();
+
+        let results = Vec::new();
+
+        // TODO: Implement dependency graph traversal
+        // This requires:
+        // 1. Getting imports from the file
+        // 2. Resolving import paths to actual files
+        // 3. Recursively following the graph
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.get_dependencies", start.elapsed());
+
+        Ok(results)
+    }
+
+    /// Get index statistics.
+    pub async fn get_stats(&self) -> Result<IndexStats, ToolError> {
+        let start = Instant::now();
+
+        let db = self.db.lock().await;
+        let stats = db.get_stats()?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.get_stats", start.elapsed());
+
+        Ok(stats)
+    }
+
+    /// Clear the entire index.
+    pub async fn clear(&self) -> Result<(), ToolError> {
+        let start = Instant::now();
+
+        let db = self.db.lock().await;
+        db.clear()?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.clear", start.elapsed());
+
+        Ok(())
+    }
+
+    /// Check if the index is empty.
+    pub async fn is_empty(&self) -> Result<bool, ToolError> {
+        let stats = self.get_stats().await?;
+        Ok(stats.total_files == 0)
+    }
+
+    /// Get a symbol's definition location.
+    pub async fn get_definition(
+        &self,
+        symbol_name: &str,
+    ) -> Result<Option<SymbolSearchResult>, ToolError> {
+        let start = Instant::now();
+
+        let db = self.db.lock().await;
+        let results = db.find_symbols(symbol_name, 10)?;
+
+        // Find exact match
+        let exact_match = results
+            .into_iter()
+            .find(|s| s.name == symbol_name);
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.get_definition", start.elapsed());
+
+        Ok(exact_match)
+    }
+
+    /// Search for files containing a symbol name.
+    pub async fn search_files(&self, query: &str) -> Result<Vec<String>, ToolError> {
+        let start = Instant::now();
+
+        let results = self.find_symbols(query, Some(100)).await?;
+        let mut files: Vec<String> = results.into_iter().map(|s| s.file).collect();
+        files.sort();
+        files.dedup();
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.search_files", start.elapsed());
+
+        Ok(files)
+    }
+
+    /// Get all symbols exported from a file.
+    pub async fn get_exports(&self, file_path: &str) -> Result<Vec<SymbolSearchResult>, ToolError> {
+        let start = Instant::now();
+
+        let symbols = self.find_symbols_in_file(file_path).await?;
+        let exports: Vec<_> = symbols
+            .into_iter()
+            .filter(|s| {
+                matches!(
+                    s.visibility,
+                    super::types::SymbolVisibility::Public
+                )
+            })
+            .collect();
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("symbol_index.service.get_exports", start.elapsed());
+
+        Ok(exports)
+    }
+
+    /// Check if indexing is currently in progress.
+    pub fn is_indexing(&self) -> bool {
+        self.indexer.is_running()
+    }
+
+    /// Get current indexing progress.
+    pub fn get_indexing_progress(&self) -> (u32, u32) {
+        self.indexer.get_progress()
+    }
+
+    /// Cancel any running indexing operation.
+    pub fn cancel_indexing(&self) {
+        self.indexer.cancel();
+    }
+}
+
+/// Builder for SymbolIndexService with fluent API.
+pub struct SymbolIndexServiceBuilder {
+    project_root: String,
+    include_patterns: Vec<String>,
+    exclude_patterns: Vec<String>,
+    parallel_jobs: usize,
+    deep_index: bool,
+}
+
+impl SymbolIndexServiceBuilder {
+    /// Create a new builder.
+    pub fn new(project_root: &str) -> Self {
+        let defaults = IndexBuildOptions::default();
+        Self {
+            project_root: project_root.to_string(),
+            include_patterns: defaults.include_patterns,
+            exclude_patterns: defaults.exclude_patterns,
+            parallel_jobs: defaults.parallel_jobs,
+            deep_index: defaults.deep_index,
+        }
+    }
+
+    /// Add include patterns.
+    pub fn include(mut self, patterns: &[&str]) -> Self {
+        self.include_patterns
+            .extend(patterns.iter().map(|s| s.to_string()));
+        self
+    }
+
+    /// Add exclude patterns.
+    pub fn exclude(mut self, patterns: &[&str]) -> Self {
+        self.exclude_patterns
+            .extend(patterns.iter().map(|s| s.to_string()));
+        self
+    }
+
+    /// Set number of parallel indexing jobs.
+    pub fn parallel_jobs(mut self, jobs: usize) -> Self {
+        self.parallel_jobs = jobs;
+        self
+    }
+
+    /// Enable deep indexing (usage-based dependency detection).
+    pub fn deep_index(mut self, enabled: bool) -> Self {
+        self.deep_index = enabled;
+        self
+    }
+
+    /// Build the service.
+    pub async fn build(self) -> Result<SymbolIndexService, ToolError> {
+        let options = IndexBuildOptions {
+            project_root: self.project_root,
+            include_patterns: self.include_patterns,
+            exclude_patterns: self.exclude_patterns,
+            force_rebuild: false,
+            deep_index: self.deep_index,
+            parallel_jobs: self.parallel_jobs,
+        };
+
+        SymbolIndexService::with_options(options).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_service_new() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path().to_str().unwrap();
+
+        let service = SymbolIndexService::new(project_root).await;
+        assert!(service.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_service_build() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        // Create test file
+        fs::write(
+            project_root.join("main.ts"),
+            r#"
+            export function greet(name: string): string {
+                return `Hello, ${name}!`;
+            }
+
+            export class Greeter {
+                private name: string;
+
+                constructor(name: string) {
+                    this.name = name;
+                }
+
+                greet(): string {
+                    return greet(this.name);
+                }
+            }
+            "#,
+        ).unwrap();
+
+        let service = SymbolIndexService::new(project_root.to_str().unwrap())
+            .await
+            .unwrap();
+
+        // Build index
+        let result = service.build(false).await.unwrap();
+        assert_eq!(result.files_indexed, 1);
+        assert!(result.total_symbols >= 2);
+
+        // Check stats
+        let stats = service.get_stats().await.unwrap();
+        assert_eq!(stats.total_files, 1);
+        assert!(stats.total_symbols >= 2);
+    }
+
+    #[tokio::test]
+    async fn test_find_symbols() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        fs::write(
+            project_root.join("lib.rs"),
+            r#"
+            pub fn hello() -> String {
+                "Hello".to_string()
+            }
+
+            pub fn world() -> String {
+                "World".to_string()
+            }
+            "#,
+        ).unwrap();
+
+        let service = SymbolIndexService::new(project_root.to_str().unwrap())
+            .await
+            .unwrap();
+
+        service.build(false).await.unwrap();
+
+        // Search for symbols
+        let results = service.find_symbols("hello", None).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "hello");
+
+        let results = service.find_symbols("world", None).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "world");
+    }
+
+    #[tokio::test]
+    async fn test_find_symbols_in_file() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        fs::write(
+            project_root.join("module.py"),
+            r#"
+def foo():
+    pass
+
+def bar():
+    pass
+
+class Baz:
+    pass
+            "#,
+        ).unwrap();
+
+        let service = SymbolIndexService::new(project_root.to_str().unwrap())
+            .await
+            .unwrap();
+
+        service.build(false).await.unwrap();
+
+        let results = service.find_symbols_in_file("module.py").await.unwrap();
+        assert!(results.len() >= 3);
+
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"foo"));
+        assert!(names.contains(&"bar"));
+        assert!(names.contains(&"Baz"));
+    }
+
+    #[tokio::test]
+    async fn test_get_definition() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        fs::write(
+            project_root.join("main.go"),
+            r#"
+package main
+
+func Main() {
+}
+
+func helper() {
+}
+            "#,
+        ).unwrap();
+
+        let service = SymbolIndexService::new(project_root.to_str().unwrap())
+            .await
+            .unwrap();
+
+        service.build(false).await.unwrap();
+
+        let def = service.get_definition("Main").await.unwrap();
+        assert!(def.is_some());
+        assert_eq!(def.unwrap().name, "Main");
+
+        let def = service.get_definition("nonexistent").await.unwrap();
+        assert!(def.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_clear_index() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        fs::write(project_root.join("test.ts"), "const x = 1;").unwrap();
+
+        let service = SymbolIndexService::new(project_root.to_str().unwrap())
+            .await
+            .unwrap();
+
+        service.build(false).await.unwrap();
+
+        let stats = service.get_stats().await.unwrap();
+        assert_eq!(stats.total_files, 1);
+
+        service.clear().await.unwrap();
+
+        let stats = service.get_stats().await.unwrap();
+        assert_eq!(stats.total_files, 0);
+    }
+
+    #[tokio::test]
+    async fn test_builder() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path().to_str().unwrap();
+
+        let service = SymbolIndexServiceBuilder::new(project_root)
+            .include(&["**/*.rs", "**/*.py"])
+            .exclude(&["**/test/**"])
+            .parallel_jobs(2)
+            .deep_index(true)
+            .build()
+            .await;
+
+        assert!(service.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_search_files() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path();
+
+        fs::write(
+            project_root.join("a.ts"),
+            "export function helper() {}",
+        ).unwrap();
+        fs::write(
+            project_root.join("b.ts"),
+            "export function helper() {}",
+        ).unwrap();
+
+        let service = SymbolIndexService::new(project_root.to_str().unwrap())
+            .await
+            .unwrap();
+
+        service.build(false).await.unwrap();
+
+        let files = service.search_files("helper").await.unwrap();
+        assert_eq!(files.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_is_empty() {
+        let temp = tempdir().unwrap();
+        let project_root = temp.path().to_str().unwrap();
+
+        let service = SymbolIndexService::new(project_root).await.unwrap();
+
+        assert!(service.is_empty().await.unwrap());
+
+        fs::write(
+            temp.path().join("test.ts"),
+            "const x = 1;",
+        ).unwrap();
+
+        service.build(false).await.unwrap();
+
+        assert!(!service.is_empty().await.unwrap());
+    }
+}

--- a/codi-rs/src/symbol_index/types.rs
+++ b/codi-rs/src/symbol_index/types.rs
@@ -1,0 +1,513 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Types for the symbol index system.
+
+use serde::{Deserialize, Serialize};
+
+/// Kind of symbol (function, class, variable, etc.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolKind {
+    Function,
+    Method,
+    Class,
+    Interface,
+    Struct,
+    Enum,
+    EnumMember,
+    Constant,
+    Variable,
+    Property,
+    Field,
+    Type,
+    TypeAlias,
+    Module,
+    Namespace,
+    Trait,
+    Impl,
+    Macro,
+    Unknown,
+}
+
+impl SymbolKind {
+    /// Convert from string representation.
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "function" | "func" | "fn" => Self::Function,
+            "method" => Self::Method,
+            "class" => Self::Class,
+            "interface" => Self::Interface,
+            "struct" => Self::Struct,
+            "enum" => Self::Enum,
+            "enum_member" | "enummember" | "variant" => Self::EnumMember,
+            "constant" | "const" => Self::Constant,
+            "variable" | "var" | "let" => Self::Variable,
+            "property" | "prop" => Self::Property,
+            "field" => Self::Field,
+            "type" => Self::Type,
+            "type_alias" | "typealias" => Self::TypeAlias,
+            "module" | "mod" => Self::Module,
+            "namespace" => Self::Namespace,
+            "trait" => Self::Trait,
+            "impl" => Self::Impl,
+            "macro" => Self::Macro,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Convert to database string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Function => "function",
+            Self::Method => "method",
+            Self::Class => "class",
+            Self::Interface => "interface",
+            Self::Struct => "struct",
+            Self::Enum => "enum",
+            Self::EnumMember => "enum_member",
+            Self::Constant => "constant",
+            Self::Variable => "variable",
+            Self::Property => "property",
+            Self::Field => "field",
+            Self::Type => "type",
+            Self::TypeAlias => "type_alias",
+            Self::Module => "module",
+            Self::Namespace => "namespace",
+            Self::Trait => "trait",
+            Self::Impl => "impl",
+            Self::Macro => "macro",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for SymbolKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Visibility of a symbol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolVisibility {
+    Public,
+    Private,
+    Protected,
+    Internal,
+    #[default]
+    Unknown,
+}
+
+impl SymbolVisibility {
+    /// Convert from string representation.
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "public" | "pub" | "export" => Self::Public,
+            "private" | "priv" => Self::Private,
+            "protected" => Self::Protected,
+            "internal" | "crate" | "pub(crate)" => Self::Internal,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Convert to database string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Public => "public",
+            Self::Private => "private",
+            Self::Protected => "protected",
+            Self::Internal => "internal",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for SymbolVisibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// A code symbol extracted from source.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeSymbol {
+    /// Symbol name.
+    pub name: String,
+    /// Kind of symbol.
+    pub kind: SymbolKind,
+    /// Start line (1-indexed).
+    pub line: u32,
+    /// End line (1-indexed), if known.
+    pub end_line: Option<u32>,
+    /// Start column (0-indexed).
+    pub column: u32,
+    /// Visibility.
+    pub visibility: SymbolVisibility,
+    /// Type signature or declaration.
+    pub signature: Option<String>,
+    /// Documentation summary.
+    pub doc_summary: Option<String>,
+    /// Additional metadata (e.g., extends, implements).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// An import statement.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportStatement {
+    /// Source path/module being imported from.
+    pub source: String,
+    /// Line number (1-indexed).
+    pub line: u32,
+    /// Whether this is a type-only import.
+    pub is_type_only: bool,
+    /// Imported symbols.
+    pub symbols: Vec<ImportedSymbol>,
+}
+
+/// An imported symbol.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportedSymbol {
+    /// Original name in the source module.
+    pub name: String,
+    /// Local alias (if renamed).
+    pub alias: Option<String>,
+    /// Whether this is the default export.
+    pub is_default: bool,
+    /// Whether this is a namespace import (import * as X).
+    pub is_namespace: bool,
+}
+
+/// Index metadata stored in the database.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexMetadata {
+    /// Index format version.
+    pub version: String,
+    /// Project root path.
+    pub project_root: String,
+    /// Last full rebuild timestamp.
+    pub last_full_rebuild: String,
+    /// Last incremental update timestamp.
+    pub last_update: String,
+    /// Total indexed files.
+    pub total_files: u32,
+    /// Total indexed symbols.
+    pub total_symbols: u32,
+}
+
+/// A file record in the index.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexedFile {
+    /// Database ID.
+    pub id: i64,
+    /// Relative file path.
+    pub path: String,
+    /// Content hash for change detection.
+    pub hash: String,
+    /// Extraction method used.
+    pub extraction_method: ExtractionMethod,
+    /// Last indexed timestamp.
+    pub last_indexed: String,
+}
+
+/// Method used to extract symbols from a file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtractionMethod {
+    /// Full AST parsing with tree-sitter.
+    TreeSitter,
+    /// Regex-based extraction (fallback).
+    Regex,
+}
+
+impl ExtractionMethod {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::TreeSitter => "tree_sitter",
+            Self::Regex => "regex",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "tree_sitter" | "ast" => Self::TreeSitter,
+            _ => Self::Regex,
+        }
+    }
+}
+
+/// A symbol record in the index.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexedSymbol {
+    /// Database ID.
+    pub id: i64,
+    /// File ID.
+    pub file_id: i64,
+    /// Symbol name.
+    pub name: String,
+    /// Symbol kind.
+    pub kind: SymbolKind,
+    /// Start line.
+    pub line: u32,
+    /// End line.
+    pub end_line: Option<u32>,
+    /// Visibility.
+    pub visibility: SymbolVisibility,
+    /// Type signature.
+    pub signature: Option<String>,
+    /// Doc summary.
+    pub doc_summary: Option<String>,
+    /// Additional metadata as JSON.
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Result from find_symbol query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SymbolSearchResult {
+    /// Symbol name.
+    pub name: String,
+    /// Symbol kind.
+    pub kind: SymbolKind,
+    /// File path.
+    pub file: String,
+    /// Line number.
+    pub line: u32,
+    /// End line.
+    pub end_line: Option<u32>,
+    /// Visibility.
+    pub visibility: SymbolVisibility,
+    /// Signature.
+    pub signature: Option<String>,
+    /// Doc summary.
+    pub doc_summary: Option<String>,
+    /// Match score (for fuzzy search).
+    pub score: f64,
+}
+
+/// Result from find_references query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReferenceResult {
+    /// File path.
+    pub file: String,
+    /// Line number.
+    pub line: u32,
+    /// Reference type.
+    pub reference_type: ReferenceType,
+    /// Context (surrounding code).
+    pub context: Option<String>,
+}
+
+/// Type of reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReferenceType {
+    Import,
+    Usage,
+    TypeOnly,
+    Definition,
+}
+
+/// Result from dependency graph query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DependencyResult {
+    /// File path.
+    pub file: String,
+    /// Direction (imports or imported_by).
+    pub direction: DependencyDirection,
+    /// Depth in the graph.
+    pub depth: u32,
+    /// Dependency type.
+    pub dependency_type: DependencyType,
+}
+
+/// Direction in dependency graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DependencyDirection {
+    Imports,
+    ImportedBy,
+}
+
+/// Type of dependency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DependencyType {
+    Import,
+    DynamicImport,
+    ReExport,
+    Usage,
+}
+
+impl DependencyType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Import => "import",
+            Self::DynamicImport => "dynamic_import",
+            Self::ReExport => "re_export",
+            Self::Usage => "usage",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "import" => Self::Import,
+            "dynamic_import" => Self::DynamicImport,
+            "re_export" => Self::ReExport,
+            "usage" => Self::Usage,
+            _ => Self::Import,
+        }
+    }
+}
+
+/// Index statistics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexStats {
+    /// Index format version.
+    pub version: String,
+    /// Project root.
+    pub project_root: String,
+    /// Total indexed files.
+    pub total_files: u32,
+    /// Total indexed symbols.
+    pub total_symbols: u32,
+    /// Total imports.
+    pub total_imports: u32,
+    /// Total dependencies.
+    pub total_dependencies: u32,
+    /// Last full rebuild.
+    pub last_full_rebuild: String,
+    /// Last update.
+    pub last_update: String,
+    /// Index size in bytes.
+    pub index_size_bytes: u64,
+}
+
+/// Options for building the index.
+#[derive(Debug, Clone)]
+pub struct IndexBuildOptions {
+    /// Project root directory.
+    pub project_root: String,
+    /// Glob patterns to include.
+    pub include_patterns: Vec<String>,
+    /// Glob patterns to exclude.
+    pub exclude_patterns: Vec<String>,
+    /// Force full rebuild.
+    pub force_rebuild: bool,
+    /// Enable deep indexing (usage-based dependency detection).
+    pub deep_index: bool,
+    /// Number of parallel jobs.
+    pub parallel_jobs: usize,
+}
+
+impl Default for IndexBuildOptions {
+    fn default() -> Self {
+        Self {
+            project_root: ".".to_string(),
+            include_patterns: vec![
+                "**/*.ts".to_string(),
+                "**/*.tsx".to_string(),
+                "**/*.js".to_string(),
+                "**/*.jsx".to_string(),
+                "**/*.rs".to_string(),
+                "**/*.py".to_string(),
+                "**/*.go".to_string(),
+            ],
+            exclude_patterns: vec![
+                "**/node_modules/**".to_string(),
+                "**/target/**".to_string(),
+                "**/.git/**".to_string(),
+                "**/dist/**".to_string(),
+                "**/build/**".to_string(),
+                "**/__pycache__/**".to_string(),
+                "**/venv/**".to_string(),
+            ],
+            force_rebuild: false,
+            deep_index: false,
+            parallel_jobs: 4,
+        }
+    }
+}
+
+/// Supported languages for symbol extraction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Language {
+    TypeScript,
+    JavaScript,
+    Rust,
+    Python,
+    Go,
+    Json,
+    Unknown,
+}
+
+impl Language {
+    /// Detect language from file extension.
+    pub fn from_extension(ext: &str) -> Self {
+        match ext.to_lowercase().as_str() {
+            "ts" | "tsx" | "mts" | "cts" => Self::TypeScript,
+            "js" | "jsx" | "mjs" | "cjs" => Self::JavaScript,
+            "rs" => Self::Rust,
+            "py" | "pyi" => Self::Python,
+            "go" => Self::Go,
+            "json" => Self::Json,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Get the file extensions for this language.
+    pub fn extensions(&self) -> &'static [&'static str] {
+        match self {
+            Self::TypeScript => &["ts", "tsx", "mts", "cts"],
+            Self::JavaScript => &["js", "jsx", "mjs", "cjs"],
+            Self::Rust => &["rs"],
+            Self::Python => &["py", "pyi"],
+            Self::Go => &["go"],
+            Self::Json => &["json"],
+            Self::Unknown => &[],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_symbol_kind_from_str() {
+        assert_eq!(SymbolKind::from_str("function"), SymbolKind::Function);
+        assert_eq!(SymbolKind::from_str("fn"), SymbolKind::Function);
+        assert_eq!(SymbolKind::from_str("class"), SymbolKind::Class);
+        assert_eq!(SymbolKind::from_str("struct"), SymbolKind::Struct);
+        assert_eq!(SymbolKind::from_str("unknown_thing"), SymbolKind::Unknown);
+    }
+
+    #[test]
+    fn test_symbol_visibility_from_str() {
+        assert_eq!(SymbolVisibility::from_str("public"), SymbolVisibility::Public);
+        assert_eq!(SymbolVisibility::from_str("pub"), SymbolVisibility::Public);
+        assert_eq!(SymbolVisibility::from_str("private"), SymbolVisibility::Private);
+        assert_eq!(SymbolVisibility::from_str("pub(crate)"), SymbolVisibility::Internal);
+    }
+
+    #[test]
+    fn test_language_from_extension() {
+        assert_eq!(Language::from_extension("ts"), Language::TypeScript);
+        assert_eq!(Language::from_extension("tsx"), Language::TypeScript);
+        assert_eq!(Language::from_extension("rs"), Language::Rust);
+        assert_eq!(Language::from_extension("py"), Language::Python);
+        assert_eq!(Language::from_extension("go"), Language::Go);
+        assert_eq!(Language::from_extension("txt"), Language::Unknown);
+    }
+
+    #[test]
+    fn test_index_build_options_default() {
+        let opts = IndexBuildOptions::default();
+        assert!(!opts.force_rebuild);
+        assert!(!opts.deep_index);
+        assert_eq!(opts.parallel_jobs, 4);
+        assert!(!opts.include_patterns.is_empty());
+        assert!(!opts.exclude_patterns.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 4 of the Rust migration: a comprehensive symbol indexing system using tree-sitter for AST parsing and SQLite for storage.

### Core Components

- **SymbolParser**: Tree-sitter based multi-language parsing
  - TypeScript, JavaScript, Rust, Python, Go support
  - Symbol extraction (functions, classes, structs, enums, interfaces, etc.)
  - Import statement tracking
  - Regex fallback for unsupported languages

- **SymbolDatabase**: SQLite storage with fuzzy search
  - Schema with files, symbols, imports, dependencies tables
  - CRUD operations with proper transaction handling
  - Fuzzy symbol search with scoring
  - Index statistics and metadata

- **Indexer**: Parallel file processing with tokio tasks
  - Configurable worker pool
  - Incremental updates (hash-based change detection)
  - Glob-based include/exclude patterns
  - Progress tracking via callbacks

- **SymbolIndexService**: High-level API
  - `build()` - Full or incremental index build
  - `find_symbols()` - Fuzzy symbol search
  - `find_symbols_by_kind()` - Filter by symbol type
  - `get_definition()` - Find symbol definition
  - `get_stats()` - Index statistics

### Telemetry Integration

All operations record metrics via `GLOBAL_METRICS`:
- `symbol_index.parser.*` - Parsing operations
- `symbol_index.db.*` - Database operations
- `symbol_index.indexer.*` - Indexing operations
- `symbol_index.service.*` - Service-level operations

### Test Coverage

- 35 unit tests covering all components
- Full workflow test with incremental updates
- Multi-language parsing tests
- Database operation tests

### Benchmarks

New `benches/symbol_index.rs` with:
- Parser benchmarks (TS, Rust, Python, various file sizes)
- Database benchmarks (open, upsert, find, stats)
- Service benchmarks (build, find_symbols, get_stats)

### Files Changed

| File | Lines | Description |
|------|-------|-------------|
| `src/symbol_index/types.rs` | 513 | Type definitions |
| `src/symbol_index/database.rs` | 647 | SQLite wrapper |
| `src/symbol_index/parser.rs` | 1,366 | Tree-sitter parsing |
| `src/symbol_index/indexer.rs` | 803 | Background indexer |
| `src/symbol_index/service.rs` | 646 | High-level API |
| `src/symbol_index/mod.rs` | 254 | Module exports |
| `benches/symbol_index.rs` | 514 | Benchmarks |

**Total: ~4,700 lines of new code**

## Test plan

- [x] `cargo test symbol_index` - 35 tests passing
- [x] `cargo check` - Clean compilation
- [x] Full test suite passes
- [ ] Run benchmarks: `cargo bench --bench symbol_index`

🤖 Generated with [Claude Code](https://claude.com/claude-code)