### PR TITLE
feat(codi-rs): Phase 5.5 Session & Context - persistence and windowing

### DIFF
--- a/codi-rs/docs/MIGRATION_PLAN.md
+++ b/codi-rs/docs/MIGRATION_PLAN.md
@@ -1,0 +1,587 @@
+# Plan: Migrate Codi from TypeScript to Rust
+
+## Executive Summary
+
+Migrate Codi CLI (~58,000 lines TypeScript, 188 files) to Rust using an **incremental hybrid approach**. A Rust core is developed alongside TypeScript with JSON-RPC interoperability, enabling gradual migration while maintaining a working product.
+
+**Estimated Timeline**: 12-14 months (with 2 developers)
+**Effort**: ~70 person-weeks
+
+---
+
+## Architectural Review (2026-02-01)
+
+### Current Rust Implementation Status
+
+```
+codi-rs: ~18,300 lines | 45 files | Phases 0-5 complete
+```
+
+### Reference Implementation Comparison
+
+| Feature | Codi-RS | Codex-RS | Crush | OpenCode | Codi-TS |
+|---------|---------|----------|-------|----------|---------|
+| Agent Loop | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Providers | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Tools | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Symbol Index | ✅ | ❌ | ❌ | ❌ | ✅ |
+| RAG System | ✅ | ❌ | ❌ | ❌ | ✅ |
+| MCP Protocol | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Sandboxing | ❌ | ✅ | ❌ | ✅ | ❌ |
+| Terminal UI | ❌ | ✅ | ✅ | ❌ | ✅ |
+| Session Mgmt | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Context Windowing | ❌ | ✅ | ✅ | ✅ | ✅ |
+| LSP Integration | ❌ | ❌ | ✅ | ✅ | ❌ |
+| OAuth/Auth | ❌ | ✅ | ✅ | ✅ | ❌ |
+| Worktrees | ❌ | ❌ | ❌ | ✅ | ✅ |
+
+### Key Insights from Reference Implementations
+
+**Codex-RS (OpenAI)** - ~30 crates, very modular:
+- Separate crates for `mcp-types`, `mcp-server`, `rmcp-client`
+- Strong security focus: `linux-sandbox`, `windows-sandbox`, `network-proxy`, `execpolicy`
+- `keyring-store` for credential management
+- Massive TUI (~240KB `chatwidget.rs`, streaming markdown)
+- OpenTelemetry via `otel` crate
+
+**Crush (Charm)** - Go with bubbletea:
+- Uses `fantasy` library for provider abstraction (like our `Provider` trait)
+- Auto-summarization when context window fills (largeContextWindowThreshold = 200K)
+- Message queuing for busy sessions
+- Title generation using small model
+- Todo tracking built into agent
+- LSP integration for diagnostics
+- Provider-specific workarounds (media in tool results for non-Anthropic)
+
+**OpenCode** - Go/TypeScript hybrid:
+- LSP integration for language features
+- PTY handling for proper terminal emulation
+- Scheduler for background tasks
+- Skill system (extensible commands)
+- Session sharing capabilities
+- Snapshot/restore for checkpoints
+- VSCode extension (`sdks/vscode`)
+
+### Missing Features (Priority Order)
+
+**Critical (Phase 6-7 blockers):**
+1. **Session Management** - Persistence, resume, history listing
+2. **Context Windowing** - Token counting, auto-summarization
+3. **Streaming Output** - Real-time callbacks for TUI integration
+
+**High Priority (Feature parity):**
+4. **MCP Protocol** - Client/server for extensibility
+5. **Slash Commands** - User command system
+6. **File Watching** - notify crate for incremental updates
+
+**Medium Priority (Polish):**
+7. **OAuth/Auth** - Keyring integration, provider auth
+8. **Title Generation** - Session naming from first message
+9. **Message Queuing** - Handle concurrent requests
+
+**Low Priority (Advanced):**
+10. **Sandboxing** - Process isolation (complex, OS-specific)
+11. **LSP Integration** - Language server features
+12. **Worktrees** - Git worktree management
+
+### Recommended Changes
+
+1. **Add Session Module (Phase 5.1)** - Before TUI, we need session persistence
+2. **Add Context Windowing (Phase 5.2)** - Critical for long conversations
+3. **Split MCP into Phase 6.5** - Between TUI and Multi-Agent
+4. **Consider Modular Crates** - Follow Codex-RS pattern for large modules
+
+---
+
+## Current State Analysis
+
+### Codi TypeScript Architecture
+```
+~58,000 lines | 188 files | Node.js 22+
+```
+
+| Component | Files | Lines | Complexity |
+|-----------|-------|-------|------------|
+| Agent Loop | 3 | ~2,600 | Very High |
+| CLI/REPL | 9 | ~3,000 | Medium |
+| Providers | 10 | ~2,000 | Medium |
+| Tools | 25 | ~4,000 | Medium |
+| Commands | 24 | ~3,500 | Medium |
+| Symbol Index | 15 | ~3,000 | High |
+| RAG System | 10 | ~2,000 | High |
+| Multi-Agent | 10 | ~2,500 | High |
+| Model Map | 17 | ~3,000 | Medium |
+| Other | ~65 | ~34,000 | Various |
+
+### Key Dependencies to Replace
+
+| TypeScript | Rust Replacement |
+|------------|------------------|
+| `@anthropic-ai/sdk` | Custom reqwest client |
+| `openai` | `async-openai` |
+| `commander` | `clap` (derive) |
+| `ink` + `react` | `ratatui` + `crossterm` |
+| `ts-morph` | `tree-sitter` |
+| `vectra` | `lance` (embedded vector DB) |
+| `better-sqlite3` | `rusqlite` |
+| `chalk` | `colored` |
+| `ora` | `indicatif` |
+
+---
+
+## Migration Strategy: Incremental Hybrid
+
+### Why Not Full Rewrite?
+- 58K LOC rewrite is 12-18 months with high failure risk
+- No releases during migration period
+- Team can't build Rust expertise gradually
+
+### Hybrid Approach
+1. Rust and TypeScript coexist via JSON-RPC
+2. Components migrate individually
+3. Each phase delivers working improvements
+4. TypeScript remains fallback during transition
+
+---
+
+## Phased Migration Plan
+
+### Phase 0: Foundation (Weeks 1-4) ✅ COMPLETE
+**Goal**: Establish Rust project structure
+
+| Task | Status |
+|------|--------|
+| Cargo workspace setup | ✅ Done |
+| Core types (Message, ToolDefinition, etc.) | ✅ Done |
+| Error handling (thiserror + anyhow) | ✅ Done |
+| Config loading (YAML/JSON with serde) | ✅ Done |
+| Basic CLI shell (clap) | ✅ Done |
+
+**Deliverable**: `codi-rs` with `codi --version` working ✅
+
+### Phase 1: Tool Layer (Weeks 5-12) ✅ COMPLETE
+**Goal**: Migrate file/shell tools for performance
+
+| Tool | Status | Notes |
+|------|--------|-------|
+| read-file, write-file, edit-file | ✅ Done | Core operations |
+| glob, grep | ✅ Done | Using `globset`, `grep` crate |
+| bash | ✅ Done | Process execution with timeout |
+| list-directory | ✅ Done | With hidden files support |
+| Telemetry infrastructure | ✅ Done | Metrics, tracing, spans |
+| Tool benchmarks | ✅ Done | Criterion-based |
+
+**Deliverable**: Tools callable from TypeScript via JSON-RPC ✅
+
+### Phase 2: Provider Layer (Weeks 13-20) ✅ COMPLETE
+**Goal**: Migrate AI provider integrations
+
+```rust
+#[async_trait]
+pub trait Provider: Send + Sync {
+    async fn chat(&self, request: ChatRequest) -> Result<ProviderResponse, ProviderError>;
+    async fn stream_chat(&self, request: ChatRequest) -> Result<StreamHandle, ProviderError>;
+    fn supports_tool_use(&self) -> bool;
+    fn supports_vision(&self) -> bool;
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, ProviderError>;
+}
+```
+
+| Provider | Status | Notes |
+|----------|--------|-------|
+| Anthropic | ✅ Done | Full streaming SSE, tool use, vision, extended thinking |
+| OpenAI | ✅ Done | OpenAI-compatible (supports OpenAI, Ollama, Azure, any compatible API) |
+| Ollama | ✅ Done | Via OpenAI-compatible provider, no API key required |
+| Smart defaults | ✅ Done | Auto-detect from env vars, local-first fallback |
+| Telemetry | ✅ Done | Operation timing, token tracking |
+| Benchmarks | ✅ Done | Provider creation, serialization, parsing |
+
+**Key Features Implemented**:
+- `create_provider_from_env()` - Auto-detects provider from environment
+- Convenience functions: `anthropic()`, `openai()`, `ollama()`, `ollama_at()`
+- Provider auto-detection from base URL
+- Feature-gated telemetry integration
+
+**Deliverable**: Rust providers with streaming, callable from TypeScript ✅
+
+### Phase 3: Agent Loop (Weeks 21-28) ✅ COMPLETE
+**Goal**: Migrate core agentic orchestration
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Agent core | ✅ Done | Central orchestration loop |
+| Tool execution | ✅ Done | Sequential execution with callbacks |
+| Confirmations | ✅ Done | Destructive tool approval flow |
+| Turn stats | ✅ Done | Token/cost/duration tracking |
+| Telemetry | ✅ Done | GLOBAL_METRICS integration |
+| Benchmarks | ✅ Done | Criterion-based agent benchmarks |
+| Context windowing | 🔜 Planned | Token management |
+| Compression | 🔜 Planned | Entity normalization |
+| Parallel execution | 🔜 Planned | Batch tool calls |
+| Streaming | 🔜 Planned | Real-time output via callbacks |
+
+**Implemented Features**:
+- `Agent.chat()` - Main agentic loop
+- `AgentConfig` - Iteration limits, timeouts, auto-approval
+- `AgentCallbacks` - Event hooks for UI integration
+- `TurnStats` - Usage tracking per turn
+- Tool confirmation for destructive operations
+
+**Deliverable**: Rust agent loop for full conversations ✅
+
+### Phase 4: Symbol Index (Weeks 29-36) ✅ COMPLETE
+**Goal**: Replace ts-morph with tree-sitter
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Type definitions | ✅ Done | SymbolKind, CodeSymbol, ImportStatement, etc. |
+| SQLite database | ✅ Done | Schema, CRUD operations, fuzzy search |
+| Tree-sitter parser | ✅ Done | TS, JS, Rust, Python, Go support |
+| Background indexer | ✅ Done | Parallel file processing with tokio |
+| High-level service | ✅ Done | SymbolIndexService API |
+| Telemetry | ✅ Done | All operations record metrics |
+| Benchmarks | ✅ Done | Parser, database, service benchmarks |
+
+**Tracked for Phase 4.1** (Issue #229):
+- File watcher with `notify` crate
+- Deep indexing with usage detection
+- Additional language support
+
+**Implemented Features**:
+- `SymbolParser` - Tree-sitter based multi-language parsing
+- `SymbolDatabase` - SQLite storage with fuzzy search
+- `Indexer` - Parallel file indexing with progress tracking
+- `SymbolIndexService` - High-level API for build, search, stats
+- Incremental updates (only re-index changed files)
+- 35 unit tests passing
+
+**Deliverable**: PR #228 merged ✅
+
+### Phase 5: RAG System (Weeks 37-42) ✅ COMPLETE
+**Goal**: Replace vectra with Rust vector search
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Types | ✅ Done | CodeChunk, RAGConfig, RetrievalResult, etc. |
+| Embedding providers | ✅ Done | OpenAI and Ollama support |
+| Embedding cache | ✅ Done | LRU cache with TTL |
+| Code chunker | ✅ Done | Semantic chunking for TS, JS, Rust, Python, Go |
+| Vector store | ✅ Done | SQLite-based with cosine similarity |
+| Background indexer | ✅ Done | Parallel file processing, incremental updates |
+| Retriever | ✅ Done | Query interface with formatted output |
+| RAGService | ✅ Done | High-level unified API |
+| Telemetry | ✅ Done | All operations record metrics |
+| Benchmarks | ✅ Done | Criterion-based |
+
+**Files Created** (~3,100 lines):
+- `src/rag/types.rs` - Type definitions
+- `src/rag/embeddings/` - Embedding providers (OpenAI, Ollama, cache)
+- `src/rag/chunker.rs` - Semantic code chunking
+- `src/rag/vector_store.rs` - SQLite-based vector storage
+- `src/rag/indexer.rs` - Background file indexer
+- `src/rag/retriever.rs` - Query interface
+- `src/rag/mod.rs` - Module exports + RAGService
+- `benches/rag.rs` - Benchmarks
+
+**Deliverable**: PR #230 (pending review)
+
+### Phase 5.5: Session & Context (NEW - Weeks 43-46)
+**Goal**: Add session persistence and context management (required before TUI)
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Session types | 🔜 Planned | Session, Message, history types |
+| Session storage | 🔜 Planned | SQLite persistence |
+| Session service | 🔜 Planned | Create, resume, list, delete |
+| Context windowing | 🔜 Planned | Token counting, truncation |
+| Auto-summarization | 🔜 Planned | Compress context when full (see Crush) |
+| Title generation | 🔜 Planned | Generate titles from first message |
+| Message queuing | 🔜 Planned | Queue requests for busy sessions |
+
+**Reference**: Crush `internal/session/`, `internal/agent/agent.go` (lines 560-671)
+
+### Phase 6: Terminal UI (Weeks 47-52)
+**Goal**: Replace ink/React with ratatui
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Core TUI framework | 🔜 Planned | ratatui + crossterm |
+| Input handling | 🔜 Planned | rustyline for readline |
+| Streaming markdown | 🔜 Planned | Real-time rendering (see Codex chatwidget.rs) |
+| Diff rendering | 🔜 Planned | Syntax-highlighted diffs |
+| Spinners/progress | 🔜 Planned | indicatif |
+| Session picker | 🔜 Planned | Resume previous sessions |
+| Slash commands | 🔜 Planned | /help, /clear, /model, etc. |
+
+**Reference**: Codex `tui/src/` (~1MB of TUI code)
+
+### Phase 6.5: MCP Protocol (NEW - Weeks 53-56)
+**Goal**: Model Context Protocol for extensibility
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| MCP types | 🔜 Planned | Separate crate like Codex |
+| MCP client | 🔜 Planned | Connect to MCP servers |
+| MCP server | 🔜 Planned | Expose tools as MCP |
+| Tool wrapping | 🔜 Planned | Wrap external tools |
+
+**Reference**: Codex `mcp-types/`, `mcp-server/`, `rmcp-client/`
+
+### Phase 7: Multi-Agent (Weeks 57-60)
+**Goal**: Port IPC-based worker orchestration
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Child agent | 🔜 Planned | Spawn sub-agents |
+| IPC protocol | 🔜 Planned | Unix sockets with tokio |
+| Commander | 🔜 Planned | Orchestrate multiple agents |
+| Worktrees | 🔜 Planned | Git worktree management |
+
+**Reference**: Codi-TS `orchestrate/`
+
+### Phase 8: Security & Polish (NEW - Weeks 61-64)
+**Goal**: Production hardening
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Command safety | 🔜 Planned | Dangerous command detection |
+| Process sandboxing | 🔜 Planned | Optional isolation (OS-specific) |
+| Credential storage | 🔜 Planned | Keyring integration |
+| OAuth flows | 🔜 Planned | Provider authentication |
+| Error recovery | 🔜 Planned | Graceful degradation |
+
+**Reference**: Codex `execpolicy/`, `linux-sandbox/`, `keyring-store/`
+
+---
+
+## Rust Crate Mapping (Current)
+
+```toml
+[dependencies]
+# Async
+tokio = { version = "1", features = ["full"] }
+async-trait = "0.1"
+
+# CLI
+clap = { version = "4", features = ["derive"] }
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
+
+# HTTP
+reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls"] }
+
+# Database
+rusqlite = { version = "0.32", features = ["bundled"] }
+
+# AST
+tree-sitter = "0.24"
+tree-sitter-typescript = "0.23"
+tree-sitter-javascript = "0.23"
+tree-sitter-rust = "0.23"
+tree-sitter-python = "0.23"
+tree-sitter-go = "0.23"
+
+# Utilities
+globset = "0.4"
+grep = "0.3"
+walkdir = "2"
+sha2 = "0.10"
+chrono = "0.4"
+lru = "0.12"
+anyhow = "1"
+thiserror = "1"
+tracing = "0.1"
+
+# Benchmarks
+[dev-dependencies]
+criterion = "0.5"
+```
+
+## Planned Dependencies (Phase 5.5+)
+
+```toml
+# Terminal UI (Phase 6)
+ratatui = "0.29"
+crossterm = "0.28"
+rustyline = "14"
+indicatif = "0.17"
+
+# Token counting (Phase 5.5)
+tiktoken-rs = "0.6"
+
+# File watching (Phase 4.1/5.5)
+notify = "7"
+
+# MCP (Phase 6.5)
+jsonrpsee = "0.24"
+
+# Git (Phase 7)
+git2 = "0.19"
+
+# Keyring (Phase 8)
+keyring = "3"
+```
+
+---
+
+## Lessons from Reference Implementations
+
+### From Codex-RS (OpenAI)
+1. **Modular crate structure** - Large modules (MCP, sandbox) as separate crates
+2. **Snapshot testing** - TUI has extensive snapshot tests (`tui/src/snapshots/`)
+3. **Protocol separation** - `codex-protocol` crate for wire types
+4. **Deny stdout/stderr** - Library code must use proper abstractions
+
+### From Crush (Charm)
+1. **Auto-summarization** - Trigger at 20% remaining context or 20K tokens for large windows
+2. **Message queuing** - Queue prompts when session is busy, process after completion
+3. **Title generation** - Use small model for efficiency, fall back to large model
+4. **Provider workarounds** - Handle provider-specific limitations (e.g., media in tool results)
+5. **Cache control** - Add Anthropic cache control to last messages for efficiency
+
+### From OpenCode
+1. **Event bus** - Central event system for component communication
+2. **Scheduler** - Background task management
+3. **Skill system** - Extensible command/behavior plugins
+
+### Patterns to Adopt
+1. **Session-first design** - All operations should be session-aware
+2. **Streaming callbacks** - TUI integration requires streaming from day 1
+3. **Graceful degradation** - Handle missing providers, network issues
+4. **Token awareness** - Track tokens throughout for context management
+
+---
+
+## Risk Assessment (Updated)
+
+### High Risk
+| Component | Risk | Mitigation |
+|-----------|------|------------|
+| ~~tree-sitter TS parsing~~ | ~~Grammar accuracy~~ | ✅ Resolved - tests passing |
+| Terminal UI | UX parity with ink | Reference Codex TUI patterns |
+| Context windowing | Token counting accuracy | Use tiktoken-rs, test with API |
+| MCP protocol | Spec compliance | Integration tests with real servers |
+
+### Medium Risk
+| Component | Risk | Mitigation |
+|-----------|------|------------|
+| ~~RAG embeddings~~ | ~~Format compatibility~~ | ✅ Resolved - tested |
+| Session migration | Data format changes | Version schema, migration scripts |
+| Multi-agent IPC | Cross-platform sockets | Abstract transport layer |
+
+### Low Risk
+| Component | Risk | Mitigation |
+|-----------|------|------------|
+| Sandboxing | OS-specific complexity | Feature-gate, optional |
+| OAuth | Provider API changes | Abstraction layer |
+
+---
+
+## Effort Summary (Updated)
+
+| Phase | Duration | Person-Weeks | Status |
+|-------|----------|--------------|--------|
+| 0: Foundation | 4 weeks | 4 | ✅ Done |
+| 1: Tools | 8 weeks | 10 | ✅ Done |
+| 2: Providers | 8 weeks | 10 | ✅ Done |
+| 3: Agent Loop | 8 weeks | 12 | ✅ Done |
+| 4: Symbol Index | 8 weeks | 12 | ✅ Done |
+| 5: RAG | 6 weeks | 8 | ✅ Done |
+| 5.5: Session & Context | 4 weeks | 6 | 🔜 Next |
+| 6: Terminal UI | 6 weeks | 10 | 🔜 Planned |
+| 6.5: MCP Protocol | 4 weeks | 6 | 🔜 Planned |
+| 7: Multi-Agent | 4 weeks | 6 | 🔜 Planned |
+| 8: Security & Polish | 4 weeks | 6 | 🔜 Planned |
+| **Total** | **64 weeks** | **90** | |
+
+**Progress**: Phases 0-5 complete (~18,300 lines, 45 files, 219 tests)
+**Remaining**: ~26 weeks (~35% done by lines, ~55% done by phases)
+
+---
+
+## Verification Strategy
+
+1. **Per-phase**: Unit tests, golden file tests vs TypeScript
+2. **Integration**: Nightly runs against live APIs
+3. **Performance**: Criterion benchmarks
+4. **Compatibility**: Same prompts through TS and Rust, compare outputs
+
+---
+
+## Quick Wins (Week 1)
+
+1. Create `codi-rs` Cargo workspace
+2. Copy gitgrip patterns (error handling, CLI, config)
+3. Implement core types (Message, ToolDefinition, etc.)
+4. Implement grep tool with `ripgrep` - immediate 10x speedup
+5. Set up GitHub Actions CI
+
+---
+
+## Files to Reference
+
+### Codi TypeScript
+| File | Purpose |
+|------|---------|
+| `codi/src/agent.ts` | Core loop (76KB) |
+| `codi/src/session.ts` | Session management |
+| `codi/src/context-windowing.ts` | Token management |
+| `codi/src/compression.ts` | Context compression |
+| `codi/src/mcp/` | MCP client/server |
+| `codi/src/orchestrate/` | Multi-agent |
+
+### Reference: Codex-RS
+| File | Purpose |
+|------|---------|
+| `ref/codex/codex-rs/core/src/lib.rs` | Core module structure |
+| `ref/codex/codex-rs/tui/src/chatwidget.rs` | Chat UI (240KB) |
+| `ref/codex/codex-rs/tui/src/markdown_stream.rs` | Streaming markdown |
+| `ref/codex/codex-rs/mcp-types/src/lib.rs` | MCP types (62KB) |
+| `ref/codex/codex-rs/execpolicy/` | Command safety |
+
+### Reference: Crush
+| File | Purpose |
+|------|---------|
+| `ref/crush/internal/agent/agent.go` | Agent with auto-summarize |
+| `ref/crush/internal/session/` | Session persistence |
+| `ref/crush/internal/ui/chat/` | Chat UI components |
+| `ref/crush/internal/lsp/` | LSP integration |
+
+### Reference: OpenCode
+| File | Purpose |
+|------|---------|
+| `ref/opencode/packages/opencode/src/` | Main CLI |
+| `ref/opencode/packages/opencode/src/session/` | Session management |
+| `ref/opencode/packages/opencode/src/mcp/` | MCP implementation |
+
+---
+
+## Next Steps
+
+### Immediate (This Week)
+1. ✅ Review and merge PR #230 (Phase 5 RAG)
+2. Create tracking issue for Phase 5.5 Session & Context
+3. Begin session types and storage design
+
+### Short Term (Next 2 Weeks)
+1. Implement session persistence
+2. Add token counting with tiktoken-rs
+3. Implement context windowing
+
+### Medium Term (Next Month)
+1. Phase 6 TUI scaffolding
+2. Streaming markdown rendering
+3. Basic slash commands
+
+---
+
+## PR Status
+
+| PR | Phase | Status |
+|----|-------|--------|
+| #228 | Phase 4 Symbol Index | ✅ Merged |
+| #229 | Phase 4.1 Tracking Issue | ✅ Created |
+| #230 | Phase 5 RAG System | 🔄 Pending Review |

--- a/codi-rs/src/lib.rs
+++ b/codi-rs/src/lib.rs
@@ -20,6 +20,7 @@
 //! - [`agent`] - Core agentic orchestration loop
 //! - [`symbol_index`] - Tree-sitter based code navigation and symbol search
 //! - [`rag`] - RAG system for semantic code search with embeddings
+//! - [`session`] - Session persistence and context windowing
 //!
 //! # Migration Status
 //!
@@ -30,7 +31,8 @@
 //! - **Phase 2**: Provider layer - Anthropic, OpenAI, Ollama ✓
 //! - **Phase 3**: Agent loop - core agentic orchestration ✓
 //! - **Phase 4**: Symbol index - tree-sitter based code navigation ✓
-//! - **Phase 5** (Current): RAG system - semantic code search with embeddings
+//! - **Phase 5**: RAG system - semantic code search with embeddings ✓
+//! - **Phase 5.5** (Current): Session & context - persistence and windowing
 //! - **Phase 6**: Terminal UI - ratatui based interface
 //! - **Phase 7**: Multi-agent - IPC-based worker orchestration
 //!
@@ -52,6 +54,7 @@ pub mod config;
 pub mod error;
 pub mod providers;
 pub mod rag;
+pub mod session;
 pub mod symbol_index;
 pub mod telemetry;
 pub mod tools;

--- a/codi-rs/src/session/context.rs
+++ b/codi-rs/src/session/context.rs
@@ -1,0 +1,548 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Context windowing and token management.
+//!
+//! Provides functionality for:
+//! - Token counting for messages
+//! - Context window management
+//! - Auto-summarization when context is full
+//! - Working set tracking for recently accessed files
+
+use std::collections::HashSet;
+use std::time::Instant;
+
+use crate::types::{ContentBlockType, Message};
+
+#[cfg(feature = "telemetry")]
+use crate::telemetry::metrics::GLOBAL_METRICS;
+
+/// Default tokens per character ratio (approximate).
+const TOKENS_PER_CHAR: f64 = 0.25;
+
+/// Configuration for context windowing.
+#[derive(Debug, Clone)]
+pub struct ContextConfig {
+    /// Maximum context window size in tokens.
+    pub max_context_tokens: u64,
+    /// Buffer to keep below max (trigger summarization when remaining < buffer).
+    pub context_buffer: u64,
+    /// Minimum recent messages to always keep.
+    pub min_recent_messages: usize,
+    /// Maximum messages to keep (hard cap).
+    pub max_messages: usize,
+    /// Whether to preserve tool_use/tool_result pairs.
+    pub preserve_tool_pairs: bool,
+}
+
+impl Default for ContextConfig {
+    fn default() -> Self {
+        Self {
+            max_context_tokens: 128_000,
+            context_buffer: 20_000,
+            min_recent_messages: 4,
+            max_messages: 50,
+            preserve_tool_pairs: true,
+        }
+    }
+}
+
+impl ContextConfig {
+    /// Create config for a specific model context window size.
+    pub fn for_model(context_window: u64) -> Self {
+        // Use 20% buffer for small windows, fixed 20K for large windows
+        let buffer = if context_window > 200_000 {
+            20_000
+        } else {
+            (context_window as f64 * 0.2) as u64
+        };
+
+        Self {
+            max_context_tokens: context_window,
+            context_buffer: buffer,
+            ..Default::default()
+        }
+    }
+
+    /// Get the threshold at which we should trigger summarization.
+    pub fn summarization_threshold(&self) -> u64 {
+        self.max_context_tokens.saturating_sub(self.context_buffer)
+    }
+}
+
+/// Tracks the current working context.
+#[derive(Debug, Clone, Default)]
+pub struct WorkingSet {
+    /// Files modified/read recently.
+    pub recent_files: HashSet<String>,
+    /// Active entities (patterns, symbols, etc.).
+    pub active_entities: HashSet<String>,
+    /// Maximum files to track.
+    pub max_files: usize,
+}
+
+impl WorkingSet {
+    /// Create a new working set.
+    pub fn new() -> Self {
+        Self {
+            recent_files: HashSet::new(),
+            active_entities: HashSet::new(),
+            max_files: 100,
+        }
+    }
+
+    /// Add a file to the working set.
+    pub fn add_file(&mut self, path: &str) {
+        self.recent_files.insert(path.to_string());
+
+        // LRU eviction (simple: just clear oldest if too many)
+        while self.recent_files.len() > self.max_files {
+            if let Some(first) = self.recent_files.iter().next().cloned() {
+                self.recent_files.remove(&first);
+            }
+        }
+    }
+
+    /// Add an entity (pattern, symbol) to track.
+    pub fn add_entity(&mut self, entity: &str) {
+        self.active_entities.insert(entity.to_string());
+    }
+
+    /// Check if a message references any files in the working set.
+    pub fn references_files(&self, text: &str) -> bool {
+        for file in &self.recent_files {
+            if text.contains(file) {
+                return true;
+            }
+            // Also check basename
+            if let Some(name) = std::path::Path::new(file).file_name() {
+                if text.contains(name.to_string_lossy().as_ref()) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Clear the working set.
+    pub fn clear(&mut self) {
+        self.recent_files.clear();
+        self.active_entities.clear();
+    }
+}
+
+/// Context window state.
+#[derive(Debug, Clone)]
+pub struct ContextWindow {
+    /// Current estimated token count.
+    pub token_count: u64,
+    /// Configuration.
+    pub config: ContextConfig,
+    /// Working set of active files.
+    pub working_set: WorkingSet,
+}
+
+impl ContextWindow {
+    /// Create a new context window.
+    pub fn new(config: ContextConfig) -> Self {
+        Self {
+            token_count: 0,
+            config,
+            working_set: WorkingSet::new(),
+        }
+    }
+
+    /// Check if we need to summarize (context is getting full).
+    pub fn needs_summarization(&self) -> bool {
+        self.token_count >= self.config.summarization_threshold()
+    }
+
+    /// Get remaining tokens before we hit the threshold.
+    pub fn remaining_tokens(&self) -> u64 {
+        self.config
+            .summarization_threshold()
+            .saturating_sub(self.token_count)
+    }
+
+    /// Get the usage percentage.
+    pub fn usage_percent(&self) -> f64 {
+        if self.config.max_context_tokens == 0 {
+            return 0.0;
+        }
+        (self.token_count as f64 / self.config.max_context_tokens as f64) * 100.0
+    }
+
+    /// Update token count from messages.
+    pub fn update_token_count(&mut self, messages: &[Message]) {
+        self.token_count = estimate_messages_tokens(messages);
+    }
+}
+
+/// Estimate tokens for a single message.
+pub fn estimate_message_tokens(message: &Message) -> u64 {
+    let start = Instant::now();
+
+    let text = get_message_text(message);
+    let tokens = estimate_text_tokens(&text);
+
+    // Add overhead for role, formatting
+    let overhead = 4;
+
+    #[cfg(feature = "telemetry")]
+    GLOBAL_METRICS.record_operation("session.context.estimate_tokens", start.elapsed());
+
+    tokens + overhead
+}
+
+/// Estimate tokens for a list of messages.
+pub fn estimate_messages_tokens(messages: &[Message]) -> u64 {
+    messages.iter().map(estimate_message_tokens).sum()
+}
+
+/// Estimate tokens for text content.
+pub fn estimate_text_tokens(text: &str) -> u64 {
+    // Simple estimation: ~4 chars per token on average
+    // This is a rough estimate; for accurate counting, use tiktoken
+    (text.len() as f64 * TOKENS_PER_CHAR) as u64
+}
+
+/// Extract text content from a message.
+pub fn get_message_text(message: &Message) -> String {
+    match &message.content {
+        crate::types::MessageContent::Text(text) => text.clone(),
+        crate::types::MessageContent::Blocks(blocks) => {
+            let mut result = String::new();
+            for block in blocks {
+                match block.block_type {
+                    ContentBlockType::Text | ContentBlockType::Thinking => {
+                        if let Some(ref t) = block.text {
+                            result.push_str(t);
+                            result.push('\n');
+                        }
+                    }
+                    ContentBlockType::ToolUse => {
+                        if let Some(ref name) = block.name {
+                            result.push_str(&format!("[Tool: {}]\n", name));
+                        }
+                        if let Some(ref input) = block.input {
+                            result.push_str(&input.to_string());
+                            result.push('\n');
+                        }
+                    }
+                    ContentBlockType::ToolResult => {
+                        if let Some(ref content) = block.content {
+                            result.push_str(content);
+                            result.push('\n');
+                        }
+                    }
+                    ContentBlockType::Image => {}
+                }
+            }
+            result
+        }
+    }
+}
+
+/// Check if a message has tool_use blocks.
+pub fn has_tool_use_blocks(message: &Message) -> bool {
+    if let crate::types::MessageContent::Blocks(blocks) = &message.content {
+        blocks
+            .iter()
+            .any(|b| b.block_type == ContentBlockType::ToolUse)
+    } else {
+        false
+    }
+}
+
+/// Check if a message has tool_result blocks.
+pub fn has_tool_result_blocks(message: &Message) -> bool {
+    if let crate::types::MessageContent::Blocks(blocks) = &message.content {
+        blocks
+            .iter()
+            .any(|b| b.block_type == ContentBlockType::ToolResult)
+    } else {
+        false
+    }
+}
+
+/// Find a safe start index that doesn't orphan tool_results.
+pub fn find_safe_start_index(messages: &[Message]) -> usize {
+    for (i, message) in messages.iter().enumerate() {
+        // If this message has tool_results, we need the previous message with tool_use
+        if has_tool_result_blocks(message) {
+            continue;
+        }
+        // Safe to start here
+        return i;
+    }
+    0
+}
+
+/// Selection result for context windowing.
+#[derive(Debug, Clone)]
+pub struct SelectionResult {
+    /// Indices of messages to keep.
+    pub keep: Vec<usize>,
+    /// Indices of messages to summarize.
+    pub summarize: Vec<usize>,
+}
+
+/// Select which messages to keep based on various criteria.
+pub fn select_messages_to_keep(
+    messages: &[Message],
+    config: &ContextConfig,
+    working_set: &WorkingSet,
+) -> SelectionResult {
+    if messages.is_empty() {
+        return SelectionResult {
+            keep: Vec::new(),
+            summarize: Vec::new(),
+        };
+    }
+
+    let mut keep = HashSet::new();
+
+    // 1. Always keep the last min_recent_messages
+    let recent_start = messages.len().saturating_sub(config.min_recent_messages);
+    for i in recent_start..messages.len() {
+        keep.insert(i);
+    }
+
+    // 2. Keep messages referencing working set files
+    for (i, message) in messages.iter().enumerate() {
+        let text = get_message_text(message);
+        if working_set.references_files(&text) {
+            keep.insert(i);
+        }
+    }
+
+    // 3. Preserve tool_use/tool_result pairs
+    if config.preserve_tool_pairs {
+        let mut to_add = Vec::new();
+        for &idx in &keep {
+            if idx < messages.len() {
+                // If this has tool_use, keep the next message (results)
+                if has_tool_use_blocks(&messages[idx]) && idx + 1 < messages.len() {
+                    to_add.push(idx + 1);
+                }
+                // If this has tool_result, keep the previous message (call)
+                if has_tool_result_blocks(&messages[idx]) && idx > 0 {
+                    to_add.push(idx - 1);
+                }
+            }
+        }
+        for idx in to_add {
+            keep.insert(idx);
+        }
+    }
+
+    // 4. Enforce max_messages cap
+    if keep.len() > config.max_messages {
+        // Keep the most recent ones
+        let mut sorted: Vec<_> = keep.iter().copied().collect();
+        sorted.sort_by(|a, b| b.cmp(a)); // Descending
+        sorted.truncate(config.max_messages);
+        keep = sorted.into_iter().collect();
+    }
+
+    // Build summarize list
+    let summarize: Vec<usize> = (0..messages.len())
+        .filter(|i| !keep.contains(i))
+        .collect();
+
+    // Sort keep indices
+    let mut keep_vec: Vec<usize> = keep.into_iter().collect();
+    keep_vec.sort();
+
+    SelectionResult {
+        keep: keep_vec,
+        summarize,
+    }
+}
+
+/// Apply selection to get kept messages.
+pub fn apply_selection(messages: &[Message], selection: &SelectionResult) -> Vec<Message> {
+    let kept: Vec<Message> = selection
+        .keep
+        .iter()
+        .filter_map(|&i| messages.get(i).cloned())
+        .collect();
+
+    // Find safe start index
+    let safe_start = find_safe_start_index(&kept);
+    kept[safe_start..].to_vec()
+}
+
+/// Statistics about context selection.
+#[derive(Debug, Clone)]
+pub struct SelectionStats {
+    /// Total messages before selection.
+    pub total_messages: usize,
+    /// Messages kept.
+    pub kept_messages: usize,
+    /// Messages to be summarized.
+    pub summarized_messages: usize,
+    /// Percentage of messages kept.
+    pub kept_percent: f64,
+    /// Files in working set.
+    pub working_set_size: usize,
+}
+
+impl SelectionStats {
+    /// Create stats from a selection.
+    pub fn from_selection(
+        messages: &[Message],
+        selection: &SelectionResult,
+        working_set: &WorkingSet,
+    ) -> Self {
+        let total = messages.len();
+        let kept = selection.keep.len();
+
+        Self {
+            total_messages: total,
+            kept_messages: kept,
+            summarized_messages: selection.summarize.len(),
+            kept_percent: if total > 0 {
+                (kept as f64 / total as f64) * 100.0
+            } else {
+                100.0
+            },
+            working_set_size: working_set.recent_files.len(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ContentBlock, Role};
+
+    fn create_text_message(role: Role, text: &str) -> Message {
+        Message {
+            role,
+            content: crate::types::MessageContent::Text(text.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_estimate_text_tokens() {
+        let text = "Hello, world!"; // 13 chars
+        let tokens = estimate_text_tokens(text);
+        // 13 * 0.25 = 3.25, rounded to 3
+        assert!(tokens >= 3 && tokens <= 5);
+    }
+
+    #[test]
+    fn test_estimate_message_tokens() {
+        let message = create_text_message(Role::User, "Hello, world!");
+        let tokens = estimate_message_tokens(&message);
+        // Text tokens + overhead
+        assert!(tokens > 0);
+    }
+
+    #[test]
+    fn test_context_config_for_model() {
+        let config = ContextConfig::for_model(200_000);
+        assert_eq!(config.max_context_tokens, 200_000);
+        assert_eq!(config.context_buffer, 40_000); // 20% of 200K
+
+        let config_large = ContextConfig::for_model(500_000);
+        assert_eq!(config_large.context_buffer, 20_000); // Fixed 20K for large
+    }
+
+    #[test]
+    fn test_context_window_needs_summarization() {
+        let config = ContextConfig {
+            max_context_tokens: 100_000,
+            context_buffer: 20_000,
+            ..Default::default()
+        };
+        let mut window = ContextWindow::new(config);
+
+        window.token_count = 50_000;
+        assert!(!window.needs_summarization());
+
+        window.token_count = 85_000; // Above 80K threshold
+        assert!(window.needs_summarization());
+    }
+
+    #[test]
+    fn test_working_set() {
+        let mut ws = WorkingSet::new();
+
+        ws.add_file("/path/to/file.rs");
+        assert!(ws.references_files("Looking at /path/to/file.rs"));
+        assert!(ws.references_files("The file.rs contains..."));
+        assert!(!ws.references_files("Some other content"));
+    }
+
+    #[test]
+    fn test_select_messages_to_keep() {
+        let messages: Vec<Message> = (0..10)
+            .map(|i| create_text_message(Role::User, &format!("Message {}", i)))
+            .collect();
+
+        let config = ContextConfig {
+            min_recent_messages: 3,
+            max_messages: 5,
+            ..Default::default()
+        };
+        let working_set = WorkingSet::new();
+
+        let result = select_messages_to_keep(&messages, &config, &working_set);
+
+        // Should keep at least min_recent_messages
+        assert!(result.keep.len() >= 3);
+        // Should keep the last messages
+        assert!(result.keep.contains(&7));
+        assert!(result.keep.contains(&8));
+        assert!(result.keep.contains(&9));
+    }
+
+    #[test]
+    fn test_has_tool_blocks() {
+        let tool_use_msg = Message {
+            role: Role::Assistant,
+            content: crate::types::MessageContent::Blocks(vec![ContentBlock::tool_use(
+                "1",
+                "test",
+                serde_json::json!({}),
+            )]),
+        };
+
+        let tool_result_msg = Message {
+            role: Role::User,
+            content: crate::types::MessageContent::Blocks(vec![ContentBlock::tool_result(
+                "1",
+                "result",
+                false,
+            )]),
+        };
+
+        assert!(has_tool_use_blocks(&tool_use_msg));
+        assert!(!has_tool_result_blocks(&tool_use_msg));
+
+        assert!(!has_tool_use_blocks(&tool_result_msg));
+        assert!(has_tool_result_blocks(&tool_result_msg));
+    }
+
+    #[test]
+    fn test_selection_stats() {
+        let messages: Vec<Message> = (0..10)
+            .map(|i| create_text_message(Role::User, &format!("Message {}", i)))
+            .collect();
+
+        let selection = SelectionResult {
+            keep: vec![7, 8, 9],
+            summarize: vec![0, 1, 2, 3, 4, 5, 6],
+        };
+
+        let working_set = WorkingSet::new();
+        let stats = SelectionStats::from_selection(&messages, &selection, &working_set);
+
+        assert_eq!(stats.total_messages, 10);
+        assert_eq!(stats.kept_messages, 3);
+        assert_eq!(stats.summarized_messages, 7);
+        assert!((stats.kept_percent - 30.0).abs() < 0.1);
+    }
+}

--- a/codi-rs/src/session/mod.rs
+++ b/codi-rs/src/session/mod.rs
@@ -1,0 +1,84 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Session management for conversation persistence and context windowing.
+//!
+//! This module provides a complete session system for managing AI conversations:
+//!
+//! - **Types**: Session, SessionMessage, SessionInfo, Todo
+//! - **Storage**: SQLite-based persistence with efficient queries
+//! - **Context**: Token counting, context windowing, working set tracking
+//! - **Service**: High-level API for session operations
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────┐
+//! │                    SessionService                            │
+//! │  (High-level API: create, save, list, get_messages, etc.)   │
+//! └─────────────────────────────────────────────────────────────┘
+//!                            │
+//!          ┌─────────────────┼─────────────────┐
+//!          ▼                 ▼                 ▼
+//! ┌─────────────────┐ ┌─────────────┐ ┌─────────────────┐
+//! │  SessionStorage │ │ ContextWindow│ │  WorkingSet    │
+//! │   (SQLite DB)   │ │   (Tokens)   │ │  (Files/Entities)│
+//! └─────────────────┘ └─────────────┘ └─────────────────┘
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use codi::session::{SessionService, WorkingSet};
+//! use codi::types::Message;
+//!
+//! // Create service
+//! let service = SessionService::new("/path/to/project").await?;
+//!
+//! // Create a session
+//! let session = service.create("My Session".to_string(), "/project".to_string()).await?;
+//!
+//! // Add messages
+//! let msg = Message::user("Hello!");
+//! service.add_message(&session.id, &msg).await?;
+//!
+//! // Get messages with context windowing
+//! let working_set = WorkingSet::new();
+//! let messages = service.apply_windowing(&session.id, &working_set).await?;
+//!
+//! // Check context state
+//! let state = service.get_context_state(&session.id).await?;
+//! if state.needs_summarization() {
+//!     println!("Context is getting full, consider summarizing");
+//! }
+//! ```
+
+pub mod context;
+pub mod service;
+pub mod storage;
+pub mod types;
+
+// Re-export commonly used types
+pub use context::{
+    apply_selection, estimate_message_tokens, estimate_messages_tokens, find_safe_start_index,
+    get_message_text, has_tool_result_blocks, has_tool_use_blocks, select_messages_to_keep,
+    ContextConfig, ContextWindow, SelectionResult, SelectionStats, WorkingSet,
+};
+pub use service::SessionService;
+pub use storage::{SessionStorage, SCHEMA_VERSION};
+pub use types::{
+    Session, SessionConfig, SessionId, SessionInfo, SessionMessage, Todo, TodoStatus,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_module_exports() {
+        // Verify key types are accessible
+        let _config = SessionConfig::default();
+        let _ctx_config = ContextConfig::default();
+        let _ws = WorkingSet::new();
+    }
+}

--- a/codi-rs/src/session/service.rs
+++ b/codi-rs/src/session/service.rs
@@ -1,0 +1,478 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Session service for managing conversation sessions.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::sync::Mutex;
+
+use crate::error::ToolError;
+use crate::types::Message;
+
+#[cfg(feature = "telemetry")]
+use crate::telemetry::metrics::GLOBAL_METRICS;
+
+use super::context::{
+    apply_selection, estimate_messages_tokens, select_messages_to_keep, ContextConfig,
+    ContextWindow, SelectionResult, SelectionStats, WorkingSet,
+};
+use super::storage::SessionStorage;
+use super::types::{Session, SessionConfig, SessionInfo, SessionMessage};
+
+/// Session service for managing conversations.
+pub struct SessionService {
+    storage: Arc<Mutex<SessionStorage>>,
+    config: SessionConfig,
+    context_config: ContextConfig,
+}
+
+impl SessionService {
+    /// Create a new session service.
+    pub fn new(project_root: &str) -> Result<Self, ToolError> {
+        Self::with_config(project_root, SessionConfig::default(), ContextConfig::default())
+    }
+
+    /// Create with custom configuration.
+    pub fn with_config(
+        project_root: &str,
+        config: SessionConfig,
+        context_config: ContextConfig,
+    ) -> Result<Self, ToolError> {
+        let start = Instant::now();
+
+        let storage = SessionStorage::open(project_root)?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.service.new", start.elapsed());
+
+        Ok(Self {
+            storage: Arc::new(Mutex::new(storage)),
+            config,
+            context_config,
+        })
+    }
+
+    /// Create with a pre-configured storage (useful for testing).
+    pub fn with_storage(storage: SessionStorage) -> Self {
+        Self {
+            storage: Arc::new(Mutex::new(storage)),
+            config: SessionConfig::default(),
+            context_config: ContextConfig::default(),
+        }
+    }
+
+    /// Create a new session.
+    pub async fn create(&self, title: String, project_path: String) -> Result<Session, ToolError> {
+        let start = Instant::now();
+
+        let id = Session::generate_id();
+        let session = Session::new(id, title, project_path);
+
+        let storage = self.storage.lock().await;
+        storage.create_session(&session)?;
+
+        // Prune old sessions if needed
+        storage.prune_sessions(self.config.max_sessions)?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.service.create", start.elapsed());
+
+        Ok(session)
+    }
+
+    /// Create a child session (for sub-agents).
+    pub async fn create_child(
+        &self,
+        parent_id: &str,
+        title: String,
+        project_path: String,
+    ) -> Result<Session, ToolError> {
+        let id = format!("child-{}-{}", parent_id, uuid::Uuid::new_v4());
+        let mut session = Session::new(id, title, project_path);
+        session.parent_id = Some(parent_id.to_string());
+
+        let storage = self.storage.lock().await;
+        storage.create_session(&session)?;
+
+        Ok(session)
+    }
+
+    /// Get a session by ID.
+    pub async fn get(&self, id: &str) -> Result<Option<Session>, ToolError> {
+        let start = Instant::now();
+
+        let storage = self.storage.lock().await;
+        let result = storage.get_session(id)?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.service.get", start.elapsed());
+
+        Ok(result)
+    }
+
+    /// Save/update a session.
+    pub async fn save(&self, session: &mut Session) -> Result<(), ToolError> {
+        let start = Instant::now();
+
+        session.touch();
+
+        let storage = self.storage.lock().await;
+        storage.update_session(session)?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.service.save", start.elapsed());
+
+        Ok(())
+    }
+
+    /// Delete a session.
+    pub async fn delete(&self, id: &str) -> Result<bool, ToolError> {
+        let start = Instant::now();
+
+        let storage = self.storage.lock().await;
+        let deleted = storage.delete_session(id)?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.service.delete", start.elapsed());
+
+        Ok(deleted)
+    }
+
+    /// List all sessions.
+    pub async fn list(&self) -> Result<Vec<SessionInfo>, ToolError> {
+        let start = Instant::now();
+
+        let storage = self.storage.lock().await;
+        let sessions = storage.list_sessions()?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.service.list", start.elapsed());
+
+        Ok(sessions)
+    }
+
+    /// Search sessions by pattern.
+    pub async fn search(&self, pattern: &str) -> Result<Vec<SessionInfo>, ToolError> {
+        let storage = self.storage.lock().await;
+        storage.search_sessions(pattern)
+    }
+
+    /// Add a message to a session.
+    pub async fn add_message(&self, session_id: &str, message: &Message) -> Result<SessionMessage, ToolError> {
+        let start = Instant::now();
+
+        let session_message = SessionMessage::from_message(session_id.to_string(), message);
+
+        let storage = self.storage.lock().await;
+        storage.add_message(&session_message)?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.service.add_message", start.elapsed());
+
+        Ok(session_message)
+    }
+
+    /// Get all messages for a session.
+    pub async fn get_messages(&self, session_id: &str) -> Result<Vec<Message>, ToolError> {
+        let start = Instant::now();
+
+        let storage = self.storage.lock().await;
+        let session_messages = storage.get_messages(session_id)?;
+
+        let messages: Vec<Message> = session_messages
+            .iter()
+            .map(SessionMessage::to_message)
+            .collect();
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.service.get_messages", start.elapsed());
+
+        Ok(messages)
+    }
+
+    /// Get message count for a session.
+    pub async fn get_message_count(&self, session_id: &str) -> Result<u32, ToolError> {
+        let storage = self.storage.lock().await;
+        storage.get_message_count(session_id)
+    }
+
+    /// Check if context needs summarization.
+    pub async fn needs_summarization(&self, session_id: &str) -> Result<bool, ToolError> {
+        let messages = self.get_messages(session_id).await?;
+        let token_count = estimate_messages_tokens(&messages);
+        Ok(token_count >= self.context_config.summarization_threshold())
+    }
+
+    /// Select messages to keep and summarize.
+    pub async fn select_for_windowing(
+        &self,
+        session_id: &str,
+        working_set: &WorkingSet,
+    ) -> Result<(SelectionResult, SelectionStats), ToolError> {
+        let messages = self.get_messages(session_id).await?;
+        let selection = select_messages_to_keep(&messages, &self.context_config, working_set);
+        let stats = SelectionStats::from_selection(&messages, &selection, working_set);
+        Ok((selection, stats))
+    }
+
+    /// Apply windowing to get the kept messages.
+    pub async fn apply_windowing(
+        &self,
+        session_id: &str,
+        working_set: &WorkingSet,
+    ) -> Result<Vec<Message>, ToolError> {
+        let messages = self.get_messages(session_id).await?;
+        let selection = select_messages_to_keep(&messages, &self.context_config, working_set);
+        Ok(apply_selection(&messages, &selection))
+    }
+
+    /// Get context window state for a session.
+    pub async fn get_context_state(&self, session_id: &str) -> Result<ContextWindow, ToolError> {
+        let messages = self.get_messages(session_id).await?;
+        let mut window = ContextWindow::new(self.context_config.clone());
+        window.update_token_count(&messages);
+        Ok(window)
+    }
+
+    /// Update session usage stats.
+    pub async fn update_usage(
+        &self,
+        session_id: &str,
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        cost: f64,
+    ) -> Result<(), ToolError> {
+        let storage = self.storage.lock().await;
+
+        if let Some(mut session) = storage.get_session(session_id)? {
+            session.add_usage(prompt_tokens, completion_tokens, cost);
+            storage.update_session(&session)?;
+        }
+
+        Ok(())
+    }
+
+    /// Set session title.
+    pub async fn set_title(&self, session_id: &str, title: String) -> Result<(), ToolError> {
+        let storage = self.storage.lock().await;
+
+        if let Some(mut session) = storage.get_session(session_id)? {
+            session.title = title;
+            session.touch();
+            storage.update_session(&session)?;
+        }
+
+        Ok(())
+    }
+
+    /// Set session label.
+    pub async fn set_label(&self, session_id: &str, label: Option<String>) -> Result<(), ToolError> {
+        let storage = self.storage.lock().await;
+
+        if let Some(mut session) = storage.get_session(session_id)? {
+            session.label = label;
+            session.touch();
+            storage.update_session(&session)?;
+        }
+
+        Ok(())
+    }
+
+    /// Set conversation summary.
+    pub async fn set_summary(&self, session_id: &str, summary: String) -> Result<(), ToolError> {
+        let storage = self.storage.lock().await;
+
+        if let Some(mut session) = storage.get_session(session_id)? {
+            session.conversation_summary = Some(summary);
+            session.touch();
+            storage.update_session(&session)?;
+        }
+
+        Ok(())
+    }
+
+    /// Get the configuration.
+    pub fn config(&self) -> &SessionConfig {
+        &self.config
+    }
+
+    /// Get the context configuration.
+    pub fn context_config(&self) -> &ContextConfig {
+        &self.context_config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn create_test_service() -> (SessionService, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("sessions.db");
+        let storage = SessionStorage::open_at(&db_path).unwrap();
+        let service = SessionService::with_storage(storage);
+        (service, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_session() {
+        let (service, _temp) = create_test_service().await;
+
+        let session = service
+            .create("Test Session".to_string(), "/path/to/project".to_string())
+            .await
+            .unwrap();
+
+        assert!(!session.id.is_empty());
+        assert_eq!(session.title, "Test Session");
+
+        let retrieved = service.get(&session.id).await.unwrap().unwrap();
+        assert_eq!(retrieved.id, session.id);
+    }
+
+    #[tokio::test]
+    async fn test_save_session() {
+        let (service, _temp) = create_test_service().await;
+
+        let mut session = service
+            .create("Original".to_string(), "/path".to_string())
+            .await
+            .unwrap();
+
+        session.title = "Updated".to_string();
+        service.save(&mut session).await.unwrap();
+
+        let retrieved = service.get(&session.id).await.unwrap().unwrap();
+        assert_eq!(retrieved.title, "Updated");
+    }
+
+    #[tokio::test]
+    async fn test_list_sessions() {
+        let (service, _temp) = create_test_service().await;
+
+        for i in 0..3 {
+            service
+                .create(format!("Session {}", i), "/path".to_string())
+                .await
+                .unwrap();
+        }
+
+        let sessions = service.list().await.unwrap();
+        assert_eq!(sessions.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_delete_session() {
+        let (service, _temp) = create_test_service().await;
+
+        let session = service
+            .create("Delete Me".to_string(), "/path".to_string())
+            .await
+            .unwrap();
+
+        assert!(service.get(&session.id).await.unwrap().is_some());
+
+        let deleted = service.delete(&session.id).await.unwrap();
+        assert!(deleted);
+
+        assert!(service.get(&session.id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_add_and_get_messages() {
+        let (service, _temp) = create_test_service().await;
+
+        let session = service
+            .create("Message Test".to_string(), "/path".to_string())
+            .await
+            .unwrap();
+
+        let msg1 = Message::user("Hello");
+        service.add_message(&session.id, &msg1).await.unwrap();
+
+        let msg2 = Message::assistant("Hi there!");
+        service.add_message(&session.id, &msg2).await.unwrap();
+
+        let messages = service.get_messages(&session.id).await.unwrap();
+        assert_eq!(messages.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_search_sessions() {
+        let (service, _temp) = create_test_service().await;
+
+        service
+            .create("Rust Project".to_string(), "/rust".to_string())
+            .await
+            .unwrap();
+        service
+            .create("Python Project".to_string(), "/python".to_string())
+            .await
+            .unwrap();
+
+        let results = service.search("rust").await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Rust Project");
+    }
+
+    #[tokio::test]
+    async fn test_update_usage() {
+        let (service, _temp) = create_test_service().await;
+
+        let session = service
+            .create("Usage Test".to_string(), "/path".to_string())
+            .await
+            .unwrap();
+
+        service
+            .update_usage(&session.id, 100, 50, 0.01)
+            .await
+            .unwrap();
+
+        let retrieved = service.get(&session.id).await.unwrap().unwrap();
+        assert_eq!(retrieved.prompt_tokens, 100);
+        assert_eq!(retrieved.completion_tokens, 50);
+        assert!((retrieved.cost - 0.01).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_set_label() {
+        let (service, _temp) = create_test_service().await;
+
+        let session = service
+            .create("Label Test".to_string(), "/path".to_string())
+            .await
+            .unwrap();
+
+        service
+            .set_label(&session.id, Some("My Label".to_string()))
+            .await
+            .unwrap();
+
+        let retrieved = service.get(&session.id).await.unwrap().unwrap();
+        assert_eq!(retrieved.label, Some("My Label".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_context_state() {
+        let (service, _temp) = create_test_service().await;
+
+        let session = service
+            .create("Context Test".to_string(), "/path".to_string())
+            .await
+            .unwrap();
+
+        // Add some messages
+        for i in 0..5 {
+            let msg = Message::user(&format!("Message {}", i));
+            service.add_message(&session.id, &msg).await.unwrap();
+        }
+
+        let state = service.get_context_state(&session.id).await.unwrap();
+        assert!(state.token_count > 0);
+        assert!(!state.needs_summarization()); // Should not need summarization with 5 messages
+    }
+}

--- a/codi-rs/src/session/storage.rs
+++ b/codi-rs/src/session/storage.rs
@@ -1,0 +1,721 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! SQLite-based session storage.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::error::ToolError;
+use crate::types::ContentBlock;
+
+#[cfg(feature = "telemetry")]
+use crate::telemetry::metrics::GLOBAL_METRICS;
+
+use super::types::{Session, SessionInfo, SessionMessage, Todo};
+
+/// Current schema version.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Session storage using SQLite.
+pub struct SessionStorage {
+    conn: Connection,
+    path: PathBuf,
+}
+
+impl SessionStorage {
+    /// Open or create a session database.
+    pub fn open(project_root: &str) -> Result<Self, ToolError> {
+        let start = Instant::now();
+
+        let codi_dir = get_sessions_directory(project_root)?;
+        std::fs::create_dir_all(&codi_dir).map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to create sessions directory: {}", e))
+        })?;
+
+        let db_path = codi_dir.join("sessions.db");
+        let result = Self::open_at(&db_path)?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.storage.open", start.elapsed());
+
+        Ok(result)
+    }
+
+    /// Open or create a session database at a specific path.
+    ///
+    /// This is useful for testing or when you want to use a custom location.
+    pub fn open_at(db_path: &Path) -> Result<Self, ToolError> {
+        // Ensure parent directory exists
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                ToolError::ExecutionFailed(format!("Failed to create directory: {}", e))
+            })?;
+        }
+
+        let conn = Connection::open(db_path).map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to open sessions database: {}", e))
+        })?;
+
+        // Enable WAL mode for better concurrency
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to set pragmas: {}", e)))?;
+
+        let mut storage = Self {
+            conn,
+            path: db_path.to_path_buf(),
+        };
+
+        storage.init_schema()?;
+
+        Ok(storage)
+    }
+
+    /// Initialize the database schema.
+    fn init_schema(&mut self) -> Result<(), ToolError> {
+        let start = Instant::now();
+
+        self.conn
+            .execute_batch(
+                r#"
+            CREATE TABLE IF NOT EXISTS schema_version (
+                version INTEGER PRIMARY KEY
+            );
+
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY,
+                parent_id TEXT,
+                title TEXT NOT NULL,
+                label TEXT,
+                project_path TEXT NOT NULL,
+                project_name TEXT,
+                provider TEXT,
+                model TEXT,
+                prompt_tokens INTEGER DEFAULT 0,
+                completion_tokens INTEGER DEFAULT 0,
+                cost REAL DEFAULT 0.0,
+                summary_message_id TEXT,
+                conversation_summary TEXT,
+                todos TEXT,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                FOREIGN KEY (parent_id) REFERENCES sessions(id)
+            );
+
+            CREATE TABLE IF NOT EXISTS session_messages (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                model TEXT,
+                provider TEXT,
+                is_summary INTEGER DEFAULT 0,
+                token_count INTEGER,
+                created_at INTEGER NOT NULL,
+                FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_sessions_updated_at ON sessions(updated_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_sessions_project_path ON sessions(project_path);
+            CREATE INDEX IF NOT EXISTS idx_messages_session_id ON session_messages(session_id);
+            CREATE INDEX IF NOT EXISTS idx_messages_created_at ON session_messages(session_id, created_at);
+            "#,
+            )
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to create schema: {}", e)))?;
+
+        // Check and update schema version
+        let current_version: Option<u32> = self
+            .conn
+            .query_row("SELECT version FROM schema_version LIMIT 1", [], |row| {
+                row.get(0)
+            })
+            .optional()
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to get schema version: {}", e)))?;
+
+        if current_version.is_none() {
+            self.conn
+                .execute(
+                    "INSERT INTO schema_version (version) VALUES (?)",
+                    params![SCHEMA_VERSION],
+                )
+                .map_err(|e| {
+                    ToolError::ExecutionFailed(format!("Failed to set schema version: {}", e))
+                })?;
+        }
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.storage.init_schema", start.elapsed());
+
+        Ok(())
+    }
+
+    /// Create a new session.
+    pub fn create_session(&self, session: &Session) -> Result<(), ToolError> {
+        let start = Instant::now();
+
+        let todos_json = serde_json::to_string(&session.todos).unwrap_or_default();
+
+        self.conn
+            .execute(
+                r#"
+            INSERT INTO sessions (
+                id, parent_id, title, label, project_path, project_name,
+                provider, model, prompt_tokens, completion_tokens, cost,
+                summary_message_id, conversation_summary, todos, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+                params![
+                    session.id,
+                    session.parent_id,
+                    session.title,
+                    session.label,
+                    session.project_path,
+                    session.project_name,
+                    session.provider,
+                    session.model,
+                    session.prompt_tokens as i64,
+                    session.completion_tokens as i64,
+                    session.cost,
+                    session.summary_message_id,
+                    session.conversation_summary,
+                    todos_json,
+                    session.created_at,
+                    session.updated_at,
+                ],
+            )
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to create session: {}", e)))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.storage.create", start.elapsed());
+
+        Ok(())
+    }
+
+    /// Update an existing session.
+    pub fn update_session(&self, session: &Session) -> Result<(), ToolError> {
+        let start = Instant::now();
+
+        let todos_json = serde_json::to_string(&session.todos).unwrap_or_default();
+
+        self.conn
+            .execute(
+                r#"
+            UPDATE sessions SET
+                parent_id = ?, title = ?, label = ?, project_path = ?, project_name = ?,
+                provider = ?, model = ?, prompt_tokens = ?, completion_tokens = ?, cost = ?,
+                summary_message_id = ?, conversation_summary = ?, todos = ?, updated_at = ?
+            WHERE id = ?
+            "#,
+                params![
+                    session.parent_id,
+                    session.title,
+                    session.label,
+                    session.project_path,
+                    session.project_name,
+                    session.provider,
+                    session.model,
+                    session.prompt_tokens as i64,
+                    session.completion_tokens as i64,
+                    session.cost,
+                    session.summary_message_id,
+                    session.conversation_summary,
+                    todos_json,
+                    session.updated_at,
+                    session.id,
+                ],
+            )
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to update session: {}", e)))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.storage.update", start.elapsed());
+
+        Ok(())
+    }
+
+    /// Get a session by ID.
+    pub fn get_session(&self, id: &str) -> Result<Option<Session>, ToolError> {
+        let start = Instant::now();
+
+        let result = self
+            .conn
+            .query_row(
+                r#"
+            SELECT id, parent_id, title, label, project_path, project_name,
+                   provider, model, prompt_tokens, completion_tokens, cost,
+                   summary_message_id, conversation_summary, todos, created_at, updated_at
+            FROM sessions WHERE id = ?
+            "#,
+                params![id],
+                |row| {
+                    let todos_json: String = row.get(13)?;
+                    let todos: Vec<Todo> =
+                        serde_json::from_str(&todos_json).unwrap_or_default();
+
+                    Ok(Session {
+                        id: row.get(0)?,
+                        parent_id: row.get(1)?,
+                        title: row.get(2)?,
+                        label: row.get(3)?,
+                        project_path: row.get(4)?,
+                        project_name: row.get(5)?,
+                        provider: row.get(6)?,
+                        model: row.get(7)?,
+                        prompt_tokens: row.get::<_, i64>(8)? as u64,
+                        completion_tokens: row.get::<_, i64>(9)? as u64,
+                        cost: row.get(10)?,
+                        summary_message_id: row.get(11)?,
+                        conversation_summary: row.get(12)?,
+                        todos,
+                        created_at: row.get(14)?,
+                        updated_at: row.get(15)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to get session: {}", e)))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.storage.get", start.elapsed());
+
+        Ok(result)
+    }
+
+    /// Delete a session and its messages.
+    pub fn delete_session(&self, id: &str) -> Result<bool, ToolError> {
+        let start = Instant::now();
+
+        // Messages are deleted via CASCADE
+        let rows = self
+            .conn
+            .execute("DELETE FROM sessions WHERE id = ?", params![id])
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to delete session: {}", e)))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.storage.delete", start.elapsed());
+
+        Ok(rows > 0)
+    }
+
+    /// List all sessions.
+    pub fn list_sessions(&self) -> Result<Vec<SessionInfo>, ToolError> {
+        let start = Instant::now();
+
+        let mut stmt = self
+            .conn
+            .prepare(
+                r#"
+            SELECT s.id, s.title, s.label, s.project_path, s.project_name,
+                   s.provider, s.model, s.prompt_tokens, s.completion_tokens, s.cost,
+                   s.summary_message_id, s.created_at, s.updated_at,
+                   (SELECT COUNT(*) FROM session_messages WHERE session_id = s.id) as message_count
+            FROM sessions s
+            ORDER BY s.updated_at DESC
+            "#,
+            )
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to prepare query: {}", e)))?;
+
+        let sessions = stmt
+            .query_map([], |row| {
+                let prompt_tokens: i64 = row.get(7)?;
+                let completion_tokens: i64 = row.get(8)?;
+                let summary_id: Option<String> = row.get(10)?;
+
+                Ok(SessionInfo {
+                    id: row.get(0)?,
+                    title: row.get(1)?,
+                    label: row.get(2)?,
+                    project_path: row.get(3)?,
+                    project_name: row.get(4)?,
+                    provider: row.get(5)?,
+                    model: row.get(6)?,
+                    total_tokens: (prompt_tokens + completion_tokens) as u64,
+                    cost: row.get(9)?,
+                    has_summary: summary_id.is_some(),
+                    created_at: row.get(11)?,
+                    updated_at: row.get(12)?,
+                    message_count: row.get(13)?,
+                })
+            })
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to query sessions: {}", e)))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to collect sessions: {}", e)))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.storage.list", start.elapsed());
+
+        Ok(sessions)
+    }
+
+    /// Search sessions by pattern.
+    pub fn search_sessions(&self, pattern: &str) -> Result<Vec<SessionInfo>, ToolError> {
+        let pattern = format!("%{}%", pattern.to_lowercase());
+
+        let mut stmt = self
+            .conn
+            .prepare(
+                r#"
+            SELECT s.id, s.title, s.label, s.project_path, s.project_name,
+                   s.provider, s.model, s.prompt_tokens, s.completion_tokens, s.cost,
+                   s.summary_message_id, s.created_at, s.updated_at,
+                   (SELECT COUNT(*) FROM session_messages WHERE session_id = s.id) as message_count
+            FROM sessions s
+            WHERE LOWER(s.title) LIKE ?
+               OR LOWER(s.label) LIKE ?
+               OR LOWER(s.project_name) LIKE ?
+               OR LOWER(s.project_path) LIKE ?
+            ORDER BY s.updated_at DESC
+            "#,
+            )
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to prepare query: {}", e)))?;
+
+        let sessions = stmt
+            .query_map(params![&pattern, &pattern, &pattern, &pattern], |row| {
+                let prompt_tokens: i64 = row.get(7)?;
+                let completion_tokens: i64 = row.get(8)?;
+                let summary_id: Option<String> = row.get(10)?;
+
+                Ok(SessionInfo {
+                    id: row.get(0)?,
+                    title: row.get(1)?,
+                    label: row.get(2)?,
+                    project_path: row.get(3)?,
+                    project_name: row.get(4)?,
+                    provider: row.get(5)?,
+                    model: row.get(6)?,
+                    total_tokens: (prompt_tokens + completion_tokens) as u64,
+                    cost: row.get(9)?,
+                    has_summary: summary_id.is_some(),
+                    created_at: row.get(11)?,
+                    updated_at: row.get(12)?,
+                    message_count: row.get(13)?,
+                })
+            })
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to search sessions: {}", e)))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                ToolError::ExecutionFailed(format!("Failed to collect search results: {}", e))
+            })?;
+
+        Ok(sessions)
+    }
+
+    /// Add a message to a session.
+    pub fn add_message(&self, message: &SessionMessage) -> Result<(), ToolError> {
+        let start = Instant::now();
+
+        let content_json = serde_json::to_string(&message.content).map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to serialize message content: {}", e))
+        })?;
+
+        let role_str = match message.role {
+            crate::types::Role::User => "user",
+            crate::types::Role::Assistant => "assistant",
+            crate::types::Role::System => "system",
+        };
+
+        self.conn
+            .execute(
+                r#"
+            INSERT INTO session_messages (
+                id, session_id, role, content, model, provider, is_summary, token_count, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+                params![
+                    message.id,
+                    message.session_id,
+                    role_str,
+                    content_json,
+                    message.model,
+                    message.provider,
+                    message.is_summary as i32,
+                    message.token_count.map(|t| t as i32),
+                    message.created_at,
+                ],
+            )
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to add message: {}", e)))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.storage.add_message", start.elapsed());
+
+        Ok(())
+    }
+
+    /// Get all messages for a session.
+    pub fn get_messages(&self, session_id: &str) -> Result<Vec<SessionMessage>, ToolError> {
+        let start = Instant::now();
+
+        let mut stmt = self
+            .conn
+            .prepare(
+                r#"
+            SELECT id, session_id, role, content, model, provider, is_summary, token_count, created_at
+            FROM session_messages
+            WHERE session_id = ?
+            ORDER BY created_at ASC
+            "#,
+            )
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to prepare query: {}", e)))?;
+
+        let messages = stmt
+            .query_map(params![session_id], |row| {
+                let role_str: String = row.get(2)?;
+                let content_json: String = row.get(3)?;
+                let is_summary: i32 = row.get(6)?;
+                let token_count: Option<i32> = row.get(7)?;
+
+                let role = match role_str.as_str() {
+                    "user" => crate::types::Role::User,
+                    "assistant" => crate::types::Role::Assistant,
+                    _ => crate::types::Role::User,
+                };
+
+                let content: Vec<ContentBlock> =
+                    serde_json::from_str(&content_json).unwrap_or_default();
+
+                Ok(SessionMessage {
+                    id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    role,
+                    content,
+                    model: row.get(4)?,
+                    provider: row.get(5)?,
+                    is_summary: is_summary != 0,
+                    token_count: token_count.map(|t| t as u32),
+                    created_at: row.get(8)?,
+                })
+            })
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to get messages: {}", e)))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to collect messages: {}", e)))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.storage.get_messages", start.elapsed());
+
+        Ok(messages)
+    }
+
+    /// Get message count for a session.
+    pub fn get_message_count(&self, session_id: &str) -> Result<u32, ToolError> {
+        let count: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_messages WHERE session_id = ?",
+                params![session_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| {
+                ToolError::ExecutionFailed(format!("Failed to get message count: {}", e))
+            })?;
+
+        Ok(count as u32)
+    }
+
+    /// Delete messages after a certain index (for truncation).
+    pub fn delete_messages_after(
+        &self,
+        session_id: &str,
+        after_timestamp: i64,
+    ) -> Result<u32, ToolError> {
+        let rows = self
+            .conn
+            .execute(
+                "DELETE FROM session_messages WHERE session_id = ? AND created_at > ?",
+                params![session_id, after_timestamp],
+            )
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to delete messages: {}", e)))?;
+
+        Ok(rows as u32)
+    }
+
+    /// Prune old sessions if we exceed the limit.
+    pub fn prune_sessions(&self, max_sessions: usize) -> Result<u32, ToolError> {
+        let start = Instant::now();
+
+        // Get count of sessions
+        let count: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to count sessions: {}", e)))?;
+
+        if count as usize <= max_sessions {
+            return Ok(0);
+        }
+
+        let to_delete = count as usize - max_sessions;
+
+        // Delete oldest sessions (excluding parent sessions with active children)
+        let deleted = self
+            .conn
+            .execute(
+                r#"
+            DELETE FROM sessions WHERE id IN (
+                SELECT id FROM sessions
+                WHERE id NOT IN (SELECT DISTINCT parent_id FROM sessions WHERE parent_id IS NOT NULL)
+                ORDER BY updated_at ASC
+                LIMIT ?
+            )
+            "#,
+                params![to_delete as i64],
+            )
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to prune sessions: {}", e)))?;
+
+        #[cfg(feature = "telemetry")]
+        GLOBAL_METRICS.record_operation("session.storage.prune", start.elapsed());
+
+        Ok(deleted as u32)
+    }
+
+    /// Get the database path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Get the sessions directory for a project.
+fn get_sessions_directory(_project_root: &str) -> Result<PathBuf, ToolError> {
+    let home = dirs::home_dir().ok_or_else(|| {
+        ToolError::ExecutionFailed("Could not determine home directory".to_string())
+    })?;
+
+    Ok(home.join(".codi").join("sessions"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_test_storage() -> (SessionStorage, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        // Override the sessions directory for testing
+        let db_path = temp_dir.path().join("sessions.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL;").unwrap();
+
+        let mut storage = SessionStorage {
+            conn,
+            path: db_path,
+        };
+        storage.init_schema().unwrap();
+
+        (storage, temp_dir)
+    }
+
+    #[test]
+    fn test_create_and_get_session() {
+        let (storage, _temp) = create_test_storage();
+
+        let session = Session::new(
+            "test-session-1".to_string(),
+            "Test Session".to_string(),
+            "/path/to/project".to_string(),
+        );
+
+        storage.create_session(&session).unwrap();
+
+        let retrieved = storage.get_session("test-session-1").unwrap().unwrap();
+        assert_eq!(retrieved.id, "test-session-1");
+        assert_eq!(retrieved.title, "Test Session");
+    }
+
+    #[test]
+    fn test_update_session() {
+        let (storage, _temp) = create_test_storage();
+
+        let mut session = Session::new(
+            "test-update".to_string(),
+            "Original Title".to_string(),
+            "/path".to_string(),
+        );
+        storage.create_session(&session).unwrap();
+
+        session.title = "Updated Title".to_string();
+        session.add_usage(100, 50, 0.01);
+        storage.update_session(&session).unwrap();
+
+        let retrieved = storage.get_session("test-update").unwrap().unwrap();
+        assert_eq!(retrieved.title, "Updated Title");
+        assert_eq!(retrieved.prompt_tokens, 100);
+        assert_eq!(retrieved.completion_tokens, 50);
+    }
+
+    #[test]
+    fn test_list_sessions() {
+        let (storage, _temp) = create_test_storage();
+
+        for i in 0..3 {
+            let session = Session::new(
+                format!("session-{}", i),
+                format!("Session {}", i),
+                "/path".to_string(),
+            );
+            storage.create_session(&session).unwrap();
+        }
+
+        let sessions = storage.list_sessions().unwrap();
+        assert_eq!(sessions.len(), 3);
+    }
+
+    #[test]
+    fn test_delete_session() {
+        let (storage, _temp) = create_test_storage();
+
+        let session = Session::new("to-delete".to_string(), "Delete Me".to_string(), "/path".to_string());
+        storage.create_session(&session).unwrap();
+
+        assert!(storage.get_session("to-delete").unwrap().is_some());
+
+        let deleted = storage.delete_session("to-delete").unwrap();
+        assert!(deleted);
+
+        assert!(storage.get_session("to-delete").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_add_and_get_messages() {
+        let (storage, _temp) = create_test_storage();
+
+        let session = Session::new("msg-test".to_string(), "Message Test".to_string(), "/path".to_string());
+        storage.create_session(&session).unwrap();
+
+        let msg1 = SessionMessage::new(
+            "msg-test".to_string(),
+            crate::types::Role::User,
+            vec![ContentBlock::text("Hello")],
+        );
+        storage.add_message(&msg1).unwrap();
+
+        let msg2 = SessionMessage::new(
+            "msg-test".to_string(),
+            crate::types::Role::Assistant,
+            vec![ContentBlock::text("Hi there!")],
+        );
+        storage.add_message(&msg2).unwrap();
+
+        let messages = storage.get_messages("msg-test").unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, crate::types::Role::User);
+        assert_eq!(messages[1].role, crate::types::Role::Assistant);
+    }
+
+    #[test]
+    fn test_search_sessions() {
+        let (storage, _temp) = create_test_storage();
+
+        let mut session = Session::new("search-1".to_string(), "Rust Project".to_string(), "/path".to_string());
+        session.project_name = Some("myproject".to_string());
+        storage.create_session(&session).unwrap();
+
+        let session2 = Session::new("search-2".to_string(), "Python Project".to_string(), "/path".to_string());
+        storage.create_session(&session2).unwrap();
+
+        let results = storage.search_sessions("rust").unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Rust Project");
+
+        let results = storage.search_sessions("myproject").unwrap();
+        assert_eq!(results.len(), 1);
+    }
+}

--- a/codi-rs/src/session/types.rs
+++ b/codi-rs/src/session/types.rs
@@ -1,0 +1,361 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Session types for conversation persistence and management.
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::{ContentBlock, Message, Role};
+
+/// Session identifier.
+pub type SessionId = String;
+
+/// A saved conversation session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    /// Unique session identifier.
+    pub id: SessionId,
+    /// Optional parent session ID (for sub-sessions).
+    pub parent_id: Option<SessionId>,
+    /// Session title (auto-generated or user-defined).
+    pub title: String,
+    /// Optional user-defined label.
+    pub label: Option<String>,
+    /// Project path where session was created.
+    pub project_path: String,
+    /// Project name.
+    pub project_name: Option<String>,
+    /// Provider used.
+    pub provider: Option<String>,
+    /// Model used.
+    pub model: Option<String>,
+    /// Total prompt tokens used.
+    pub prompt_tokens: u64,
+    /// Total completion tokens used.
+    pub completion_tokens: u64,
+    /// Total cost in USD.
+    pub cost: f64,
+    /// ID of the summary message (for context windowing).
+    pub summary_message_id: Option<String>,
+    /// Current conversation summary (if compacted).
+    pub conversation_summary: Option<String>,
+    /// Todo items tracked in this session.
+    pub todos: Vec<Todo>,
+    /// Creation timestamp (Unix epoch seconds).
+    pub created_at: i64,
+    /// Last update timestamp (Unix epoch seconds).
+    pub updated_at: i64,
+}
+
+impl Session {
+    /// Create a new session with default values.
+    pub fn new(id: SessionId, title: String, project_path: String) -> Self {
+        let now = chrono::Utc::now().timestamp();
+        Self {
+            id,
+            parent_id: None,
+            title,
+            label: None,
+            project_path,
+            project_name: None,
+            provider: None,
+            model: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cost: 0.0,
+            summary_message_id: None,
+            conversation_summary: None,
+            todos: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Generate a unique session ID based on timestamp and UUID.
+    pub fn generate_id() -> SessionId {
+        let now = chrono::Utc::now();
+        let short_uuid = &uuid::Uuid::new_v4().to_string()[..8];
+        format!("session-{}-{}", now.format("%Y-%m-%d-%H-%M-%S"), short_uuid)
+    }
+
+    /// Update the session's updated_at timestamp.
+    pub fn touch(&mut self) {
+        self.updated_at = chrono::Utc::now().timestamp();
+    }
+
+    /// Add token usage to the session.
+    pub fn add_usage(&mut self, prompt_tokens: u64, completion_tokens: u64, cost: f64) {
+        self.prompt_tokens += prompt_tokens;
+        self.completion_tokens += completion_tokens;
+        self.cost += cost;
+        self.touch();
+    }
+
+    /// Get total tokens used.
+    pub fn total_tokens(&self) -> u64 {
+        self.prompt_tokens + self.completion_tokens
+    }
+}
+
+/// Session metadata for listing (without full message history).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionInfo {
+    /// Session ID.
+    pub id: SessionId,
+    /// Session title.
+    pub title: String,
+    /// Optional label.
+    pub label: Option<String>,
+    /// Project path.
+    pub project_path: String,
+    /// Project name.
+    pub project_name: Option<String>,
+    /// Provider used.
+    pub provider: Option<String>,
+    /// Model used.
+    pub model: Option<String>,
+    /// Number of messages.
+    pub message_count: u32,
+    /// Whether the session has a summary.
+    pub has_summary: bool,
+    /// Total tokens used.
+    pub total_tokens: u64,
+    /// Total cost.
+    pub cost: f64,
+    /// Creation timestamp.
+    pub created_at: i64,
+    /// Last update timestamp.
+    pub updated_at: i64,
+}
+
+impl SessionInfo {
+    /// Format the session info for display.
+    pub fn format(&self) -> String {
+        let date = chrono::DateTime::from_timestamp(self.updated_at, 0)
+            .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let mut display = self.title.clone();
+        if let Some(ref label) = self.label {
+            display.push_str(&format!(": \"{}\"", label));
+        }
+        display.push_str(&format!(" ({} msgs", self.message_count));
+        if self.has_summary {
+            display.push_str(", summarized");
+        }
+        display.push(')');
+        display.push_str(&format!(" - {}", date));
+
+        if let Some(ref name) = self.project_name {
+            display.push_str(&format!(" [{}]", name));
+        }
+
+        display
+    }
+}
+
+/// A message stored in a session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMessage {
+    /// Unique message ID.
+    pub id: String,
+    /// Session this message belongs to.
+    pub session_id: SessionId,
+    /// Message role.
+    pub role: Role,
+    /// Message content blocks.
+    pub content: Vec<ContentBlock>,
+    /// Optional model that generated this message.
+    pub model: Option<String>,
+    /// Optional provider.
+    pub provider: Option<String>,
+    /// Whether this is a summary message.
+    pub is_summary: bool,
+    /// Token count for this message.
+    pub token_count: Option<u32>,
+    /// Creation timestamp.
+    pub created_at: i64,
+}
+
+impl SessionMessage {
+    /// Create a new session message.
+    pub fn new(session_id: SessionId, role: Role, content: Vec<ContentBlock>) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            session_id,
+            role,
+            content,
+            model: None,
+            provider: None,
+            is_summary: false,
+            token_count: None,
+            created_at: chrono::Utc::now().timestamp(),
+        }
+    }
+
+    /// Convert to a Message for API calls.
+    pub fn to_message(&self) -> Message {
+        Message {
+            role: self.role,
+            content: crate::types::MessageContent::Blocks(self.content.clone()),
+        }
+    }
+
+    /// Create from a Message.
+    pub fn from_message(session_id: SessionId, message: &Message) -> Self {
+        let content = match &message.content {
+            crate::types::MessageContent::Text(text) => {
+                vec![ContentBlock::text(text.clone())]
+            }
+            crate::types::MessageContent::Blocks(blocks) => blocks.clone(),
+        };
+
+        Self::new(session_id, message.role, content)
+    }
+}
+
+/// Todo item tracked in a session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Todo {
+    /// Todo content/description.
+    pub content: String,
+    /// Current status.
+    pub status: TodoStatus,
+    /// Active form for display (e.g., "Running tests...").
+    pub active_form: Option<String>,
+}
+
+impl Todo {
+    /// Create a new pending todo.
+    pub fn new(content: String) -> Self {
+        Self {
+            content,
+            status: TodoStatus::Pending,
+            active_form: None,
+        }
+    }
+}
+
+/// Status of a todo item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TodoStatus {
+    /// Not started.
+    Pending,
+    /// Currently in progress.
+    InProgress,
+    /// Completed.
+    Completed,
+}
+
+impl std::fmt::Display for TodoStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => write!(f, "pending"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
+        }
+    }
+}
+
+/// Configuration for session management.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionConfig {
+    /// Maximum sessions to keep (oldest are pruned).
+    pub max_sessions: usize,
+    /// Whether to auto-save sessions.
+    pub auto_save: bool,
+    /// Auto-save interval in seconds.
+    pub auto_save_interval_secs: u64,
+    /// Whether to generate titles automatically.
+    pub auto_generate_titles: bool,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            max_sessions: 100,
+            auto_save: true,
+            auto_save_interval_secs: 30,
+            auto_generate_titles: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_new() {
+        let session = Session::new(
+            "test-id".to_string(),
+            "Test Session".to_string(),
+            "/path/to/project".to_string(),
+        );
+
+        assert_eq!(session.id, "test-id");
+        assert_eq!(session.title, "Test Session");
+        assert_eq!(session.project_path, "/path/to/project");
+        assert!(session.created_at > 0);
+        assert_eq!(session.created_at, session.updated_at);
+    }
+
+    #[test]
+    fn test_session_generate_id() {
+        let id = Session::generate_id();
+        assert!(id.starts_with("session-"));
+    }
+
+    #[test]
+    fn test_session_add_usage() {
+        let mut session = Session::new(
+            "test".to_string(),
+            "Test".to_string(),
+            "/path".to_string(),
+        );
+
+        session.add_usage(100, 50, 0.001);
+        assert_eq!(session.prompt_tokens, 100);
+        assert_eq!(session.completion_tokens, 50);
+        assert!((session.cost - 0.001).abs() < 0.0001);
+
+        session.add_usage(200, 100, 0.002);
+        assert_eq!(session.prompt_tokens, 300);
+        assert_eq!(session.completion_tokens, 150);
+        assert_eq!(session.total_tokens(), 450);
+    }
+
+    #[test]
+    fn test_session_info_format() {
+        let info = SessionInfo {
+            id: "test".to_string(),
+            title: "Test Session".to_string(),
+            label: Some("My Label".to_string()),
+            project_path: "/path".to_string(),
+            project_name: Some("myproject".to_string()),
+            provider: Some("anthropic".to_string()),
+            model: Some("claude-3".to_string()),
+            message_count: 10,
+            has_summary: true,
+            total_tokens: 1000,
+            cost: 0.01,
+            created_at: 0,
+            updated_at: 0,
+        };
+
+        let formatted = info.format();
+        assert!(formatted.contains("Test Session"));
+        assert!(formatted.contains("My Label"));
+        assert!(formatted.contains("10 msgs"));
+        assert!(formatted.contains("summarized"));
+        assert!(formatted.contains("[myproject]"));
+    }
+
+    #[test]
+    fn test_todo_status() {
+        let todo = Todo::new("Write tests".to_string());
+        assert_eq!(todo.status, TodoStatus::Pending);
+        assert_eq!(todo.status.to_string(), "pending");
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 5.5 of the Rust migration: Session management and context windowing.

**New Files Created (~2,800 lines):**
- `src/session/types.rs` - Session, SessionMessage, SessionInfo, Todo types
- `src/session/storage.rs` - SQLite-based session persistence
- `src/session/context.rs` - Context windowing and token estimation
- `src/session/service.rs` - High-level SessionService API
- `src/session/mod.rs` - Module exports
- `docs/MIGRATION_PLAN.md` - Updated migration roadmap

**Key Features:**
- Session persistence with SQLite (WAL mode for concurrency)
- Context window management with configurable token limits
- Working set tracking for recently accessed files
- Tool use/result pair preservation during windowing
- Session search and pruning functionality
- 29 new tests for the session module

**Architecture Patterns (from reference implementations):**
- Auto-summarization threshold at 80% capacity (following Crush pattern)
- Message selection that preserves tool call pairs
- Token estimation at ~0.25 tokens/character

## Test plan
- [x] Run `cargo test session --lib` - 29 tests passing
- [x] Run `cargo test --lib` - 248 total tests passing
- [x] Verify compilation with `cargo check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)