### PR TITLE
feat(codi-rs): Phase 6 Terminal UI - ratatui based interface

### DIFF
--- a/codi-rs/Cargo.toml
+++ b/codi-rs/Cargo.toml
@@ -45,10 +45,10 @@ clap = { version = "4", features = ["derive", "env"] }
 colored = "2"
 indicatif = "0.17"
 
-# Terminal UI (for later phases)
-# ratatui = "0.29"
-# crossterm = "0.28"
-# rustyline = "14"
+# Terminal UI (Phase 6)
+ratatui = "0.29"
+crossterm = "0.28"
+rustyline = { version = "15", features = ["derive"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/codi-rs/src/lib.rs
+++ b/codi-rs/src/lib.rs
@@ -32,8 +32,8 @@
 //! - **Phase 3**: Agent loop - core agentic orchestration ✓
 //! - **Phase 4**: Symbol index - tree-sitter based code navigation ✓
 //! - **Phase 5**: RAG system - semantic code search with embeddings ✓
-//! - **Phase 5.5** (Current): Session & context - persistence and windowing
-//! - **Phase 6**: Terminal UI - ratatui based interface
+//! - **Phase 5.5**: Session & context - persistence and windowing ✓
+//! - **Phase 6** (Current): Terminal UI - ratatui based interface
 //! - **Phase 7**: Multi-agent - IPC-based worker orchestration
 //!
 //! # Example
@@ -58,6 +58,7 @@ pub mod session;
 pub mod symbol_index;
 pub mod telemetry;
 pub mod tools;
+pub mod tui;
 pub mod types;
 
 // Re-export commonly used types at crate root

--- a/codi-rs/src/tui/app.rs
+++ b/codi-rs/src/tui/app.rs
@@ -1,0 +1,340 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Application state and main loop for the TUI.
+
+use std::io;
+
+use crossterm::event::KeyCode;
+use ratatui::prelude::*;
+
+use crate::types::{BoxedProvider, Role};
+
+use super::commands::handle_command;
+use super::events::{Event, EventHandler};
+use super::ui;
+
+/// Application mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppMode {
+    /// Normal input mode.
+    Normal,
+    /// Waiting for AI response.
+    Waiting,
+    /// Showing help.
+    Help,
+}
+
+/// A message in the conversation.
+#[derive(Debug, Clone)]
+pub struct Message {
+    /// Message role (user or assistant).
+    pub role: Role,
+    /// Message content.
+    pub content: String,
+    /// Whether this message is still being streamed.
+    pub streaming: bool,
+}
+
+impl Message {
+    /// Create a user message.
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::User,
+            content: content.into(),
+            streaming: false,
+        }
+    }
+
+    /// Create an assistant message.
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: content.into(),
+            streaming: false,
+        }
+    }
+
+    /// Create a streaming assistant message.
+    pub fn streaming() -> Self {
+        Self {
+            role: Role::Assistant,
+            content: String::new(),
+            streaming: true,
+        }
+    }
+}
+
+/// Application state.
+pub struct App {
+    /// Current mode.
+    pub mode: AppMode,
+    /// Conversation messages.
+    pub messages: Vec<Message>,
+    /// Current input text.
+    pub input: String,
+    /// Cursor position in input.
+    pub cursor_pos: usize,
+    /// Scroll offset for messages.
+    pub scroll_offset: u16,
+    /// Whether the app should quit.
+    pub should_quit: bool,
+    /// Status message to display.
+    pub status: Option<String>,
+    /// AI provider.
+    provider: Option<BoxedProvider>,
+}
+
+impl App {
+    /// Create a new application.
+    pub fn new() -> Self {
+        Self {
+            mode: AppMode::Normal,
+            messages: Vec::new(),
+            input: String::new(),
+            cursor_pos: 0,
+            scroll_offset: 0,
+            should_quit: false,
+            status: None,
+            provider: None,
+        }
+    }
+
+    /// Create with a provider.
+    pub fn with_provider(provider: BoxedProvider) -> Self {
+        Self {
+            provider: Some(provider),
+            ..Self::new()
+        }
+    }
+
+    /// Run the main event loop.
+    pub async fn run<B: Backend>(
+        &mut self,
+        terminal: &mut Terminal<B>,
+        mut events: EventHandler,
+    ) -> io::Result<()> {
+        while !self.should_quit {
+            // Draw UI
+            terminal.draw(|f| ui::draw(f, self))?;
+
+            // Handle events
+            if let Some(event) = events.next().await {
+                self.handle_event(event).await;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handle an input event.
+    async fn handle_event(&mut self, event: Event) {
+        match event {
+            Event::Tick => {}
+            Event::Key(key) => self.handle_key(key.code).await,
+            Event::Mouse(_) => {}
+            Event::Resize(_, _) => {}
+        }
+    }
+
+    /// Handle a key press.
+    async fn handle_key(&mut self, key: KeyCode) {
+        match self.mode {
+            AppMode::Normal => self.handle_normal_key(key).await,
+            AppMode::Waiting => self.handle_waiting_key(key),
+            AppMode::Help => self.handle_help_key(key),
+        }
+    }
+
+    /// Handle key in normal mode.
+    async fn handle_normal_key(&mut self, key: KeyCode) {
+        match key {
+            KeyCode::Enter => {
+                if !self.input.is_empty() {
+                    self.submit_input().await;
+                }
+            }
+            KeyCode::Char(c) => {
+                self.input.insert(self.cursor_pos, c);
+                self.cursor_pos += 1;
+            }
+            KeyCode::Backspace => {
+                if self.cursor_pos > 0 {
+                    self.cursor_pos -= 1;
+                    self.input.remove(self.cursor_pos);
+                }
+            }
+            KeyCode::Delete => {
+                if self.cursor_pos < self.input.len() {
+                    self.input.remove(self.cursor_pos);
+                }
+            }
+            KeyCode::Left => {
+                if self.cursor_pos > 0 {
+                    self.cursor_pos -= 1;
+                }
+            }
+            KeyCode::Right => {
+                if self.cursor_pos < self.input.len() {
+                    self.cursor_pos += 1;
+                }
+            }
+            KeyCode::Home => {
+                self.cursor_pos = 0;
+            }
+            KeyCode::End => {
+                self.cursor_pos = self.input.len();
+            }
+            KeyCode::Up => {
+                if self.scroll_offset > 0 {
+                    self.scroll_offset -= 1;
+                }
+            }
+            KeyCode::Down => {
+                self.scroll_offset += 1;
+            }
+            KeyCode::PageUp => {
+                self.scroll_offset = self.scroll_offset.saturating_sub(10);
+            }
+            KeyCode::PageDown => {
+                self.scroll_offset += 10;
+            }
+            KeyCode::Esc => {
+                self.should_quit = true;
+            }
+            _ => {}
+        }
+    }
+
+    /// Handle key while waiting for response.
+    fn handle_waiting_key(&mut self, key: KeyCode) {
+        if key == KeyCode::Esc {
+            // Cancel request (TODO: actually cancel)
+            self.mode = AppMode::Normal;
+            self.status = Some("Cancelled".to_string());
+        }
+    }
+
+    /// Handle key in help mode.
+    fn handle_help_key(&mut self, key: KeyCode) {
+        if key == KeyCode::Esc || key == KeyCode::Char('q') || key == KeyCode::Enter {
+            self.mode = AppMode::Normal;
+        }
+    }
+
+    /// Submit the current input.
+    async fn submit_input(&mut self) {
+        let input = std::mem::take(&mut self.input);
+        self.cursor_pos = 0;
+
+        // Check for commands
+        if input.starts_with('/') {
+            handle_command(self, &input);
+            return;
+        }
+
+        // Add user message
+        self.messages.push(Message::user(&input));
+
+        // Get AI response
+        if let Some(ref provider) = self.provider {
+            self.mode = AppMode::Waiting;
+            self.status = Some("Thinking...".to_string());
+
+            // Convert messages to API format
+            let api_messages: Vec<crate::types::Message> = self
+                .messages
+                .iter()
+                .filter(|m| !m.streaming)
+                .map(|m| crate::types::Message {
+                    role: m.role,
+                    content: crate::types::MessageContent::Text(m.content.clone()),
+                })
+                .collect();
+
+            // Call the provider
+            match provider.chat(&api_messages, None, None).await {
+                Ok(response) => {
+                    self.messages.push(Message::assistant(&response.content));
+                    self.status = None;
+                }
+                Err(e) => {
+                    self.status = Some(format!("Error: {}", e));
+                }
+            }
+
+            self.mode = AppMode::Normal;
+        } else {
+            // No provider, just echo
+            self.messages.push(Message::assistant(
+                "No AI provider configured. Use --provider to specify one.",
+            ));
+        }
+    }
+
+    /// Clear conversation history.
+    pub fn clear_messages(&mut self) {
+        self.messages.clear();
+        self.scroll_offset = 0;
+        self.status = Some("Conversation cleared".to_string());
+    }
+
+    /// Show help.
+    pub fn show_help(&mut self) {
+        self.mode = AppMode::Help;
+    }
+}
+
+impl App {
+    /// Check if a provider is configured.
+    pub fn has_provider(&self) -> bool {
+        self.provider.is_some()
+    }
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_app_new() {
+        let app = App::new();
+        assert_eq!(app.mode, AppMode::Normal);
+        assert!(app.messages.is_empty());
+        assert!(app.input.is_empty());
+    }
+
+    #[test]
+    fn test_message_user() {
+        let msg = Message::user("Hello");
+        assert_eq!(msg.role, Role::User);
+        assert_eq!(msg.content, "Hello");
+        assert!(!msg.streaming);
+    }
+
+    #[test]
+    fn test_message_assistant() {
+        let msg = Message::assistant("Hi there");
+        assert_eq!(msg.role, Role::Assistant);
+        assert_eq!(msg.content, "Hi there");
+        assert!(!msg.streaming);
+    }
+
+    #[test]
+    fn test_clear_messages() {
+        let mut app = App::new();
+        app.messages.push(Message::user("test"));
+        app.messages.push(Message::assistant("response"));
+
+        app.clear_messages();
+
+        assert!(app.messages.is_empty());
+        assert!(app.status.is_some());
+    }
+}

--- a/codi-rs/src/tui/commands.rs
+++ b/codi-rs/src/tui/commands.rs
@@ -1,0 +1,81 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Slash command handling for the TUI.
+
+use super::app::App;
+
+/// Handle a slash command.
+pub fn handle_command(app: &mut App, input: &str) {
+    let parts: Vec<&str> = input.trim().splitn(2, ' ').collect();
+    let command = parts[0].to_lowercase();
+    let _args = parts.get(1).copied().unwrap_or("");
+
+    match command.as_str() {
+        "/help" | "/h" | "/?" => {
+            app.show_help();
+        }
+        "/clear" | "/c" => {
+            app.clear_messages();
+        }
+        "/exit" | "/quit" | "/q" => {
+            app.should_quit = true;
+        }
+        "/version" | "/v" => {
+            app.status = Some(format!("Codi v{}", crate::VERSION));
+        }
+        _ => {
+            app.status = Some(format!("Unknown command: {}. Type /help for commands.", command));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_help_command() {
+        let mut app = App::default();
+        handle_command(&mut app, "/help");
+        assert_eq!(app.mode, super::super::app::AppMode::Help);
+    }
+
+    #[test]
+    fn test_clear_command() {
+        let mut app = App::default();
+        app.messages.push(super::super::app::Message::user("test"));
+        handle_command(&mut app, "/clear");
+        assert!(app.messages.is_empty());
+    }
+
+    #[test]
+    fn test_exit_command() {
+        let mut app = App::default();
+        handle_command(&mut app, "/exit");
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn test_quit_command() {
+        let mut app = App::default();
+        handle_command(&mut app, "/quit");
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn test_version_command() {
+        let mut app = App::default();
+        handle_command(&mut app, "/version");
+        assert!(app.status.is_some());
+        assert!(app.status.as_ref().unwrap().contains("Codi"));
+    }
+
+    #[test]
+    fn test_unknown_command() {
+        let mut app = App::default();
+        handle_command(&mut app, "/unknown");
+        assert!(app.status.is_some());
+        assert!(app.status.as_ref().unwrap().contains("Unknown command"));
+    }
+}

--- a/codi-rs/src/tui/events.rs
+++ b/codi-rs/src/tui/events.rs
@@ -1,0 +1,99 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Event handling for the TUI.
+
+use std::time::Duration;
+
+use crossterm::event::{self, Event as CrosstermEvent, KeyEvent, MouseEvent};
+use tokio::sync::mpsc;
+use tokio::time::interval;
+
+/// Terminal events.
+#[derive(Debug, Clone)]
+pub enum Event {
+    /// A tick event for periodic updates.
+    Tick,
+    /// A key press event.
+    Key(KeyEvent),
+    /// A mouse event.
+    Mouse(MouseEvent),
+    /// Terminal resize event.
+    Resize(u16, u16),
+}
+
+/// Event handler that polls for terminal events.
+pub struct EventHandler {
+    /// Event receiver channel.
+    rx: mpsc::UnboundedReceiver<Event>,
+    /// Handle to the event sender task.
+    _tx: mpsc::UnboundedSender<Event>,
+}
+
+impl EventHandler {
+    /// Create a new event handler with the given tick rate in milliseconds.
+    pub fn new(tick_rate_ms: u64) -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let tx_clone = tx.clone();
+        let tick_rate = Duration::from_millis(tick_rate_ms);
+
+        // Spawn the event polling task
+        tokio::spawn(async move {
+            let mut ticker = interval(tick_rate);
+
+            loop {
+                let event = tokio::select! {
+                    _ = ticker.tick() => Event::Tick,
+                    event = poll_event() => event,
+                };
+
+                if tx_clone.send(event).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Self { rx, _tx: tx }
+    }
+
+    /// Get the next event, if available.
+    pub async fn next(&mut self) -> Option<Event> {
+        self.rx.recv().await
+    }
+}
+
+/// Poll for a crossterm event.
+async fn poll_event() -> Event {
+    // Use a short poll timeout so we don't block too long
+    loop {
+        if event::poll(Duration::from_millis(50)).unwrap_or(false) {
+            if let Ok(event) = event::read() {
+                return match event {
+                    CrosstermEvent::Key(key) => Event::Key(key),
+                    CrosstermEvent::Mouse(mouse) => Event::Mouse(mouse),
+                    CrosstermEvent::Resize(w, h) => Event::Resize(w, h),
+                    _ => continue,
+                };
+            }
+        }
+        // Yield to allow other tasks to run
+        tokio::task::yield_now().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_event_types() {
+        let tick = Event::Tick;
+        assert!(matches!(tick, Event::Tick));
+
+        let resize = Event::Resize(80, 24);
+        if let Event::Resize(w, h) = resize {
+            assert_eq!(w, 80);
+            assert_eq!(h, 24);
+        }
+    }
+}

--- a/codi-rs/src/tui/mod.rs
+++ b/codi-rs/src/tui/mod.rs
@@ -1,0 +1,93 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Terminal User Interface for Codi.
+//!
+//! This module provides a ratatui-based terminal interface for interactive
+//! conversations with AI models.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────┐
+//! │                        App                                  │
+//! │  (Application state: messages, input, mode, session)        │
+//! └─────────────────────────────────────────────────────────────┘
+//!                            │
+//!          ┌─────────────────┼─────────────────┐
+//!          ▼                 ▼                 ▼
+//! ┌─────────────────┐ ┌─────────────┐ ┌─────────────────┐
+//! │     Events      │ │     UI      │ │    Commands     │
+//! │  (Keyboard/Term)│ │  (Render)   │ │  (Slash cmds)   │
+//! └─────────────────┘ └─────────────┘ └─────────────────┘
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use codi::tui::{App, run};
+//!
+//! // Create the app with a provider
+//! let provider = create_provider_from_env()?;
+//! let mut app = App::new(provider);
+//!
+//! // Run the TUI event loop
+//! run(&mut app)?;
+//! ```
+
+pub mod app;
+pub mod commands;
+pub mod events;
+pub mod ui;
+
+pub use app::{App, AppMode, Message as ChatMessage};
+pub use events::{Event, EventHandler};
+
+use std::io;
+use crossterm::{
+    event::{DisableMouseCapture, EnableMouseCapture},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::prelude::*;
+
+/// Initialize the terminal for TUI mode.
+pub fn init_terminal() -> io::Result<Terminal<CrosstermBackend<io::Stdout>>> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    Terminal::new(backend)
+}
+
+/// Restore the terminal to normal mode.
+pub fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<()> {
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+    Ok(())
+}
+
+/// Run the TUI application.
+pub async fn run(app: &mut App) -> io::Result<()> {
+    let mut terminal = init_terminal()?;
+    let events = EventHandler::new(250);
+
+    let result = app.run(&mut terminal, events).await;
+
+    restore_terminal(&mut terminal)?;
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_module_exports() {
+        // Verify key types are accessible
+        // Note: Can't test terminal init/restore in unit tests
+    }
+}

--- a/codi-rs/src/tui/ui.rs
+++ b/codi-rs/src/tui/ui.rs
@@ -1,0 +1,244 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! UI rendering for the TUI.
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::types::Role;
+
+use super::app::{App, AppMode};
+
+/// Draw the main UI.
+pub fn draw(f: &mut Frame, app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(3),    // Messages area
+            Constraint::Length(3), // Input area
+            Constraint::Length(1), // Status bar
+        ])
+        .split(f.area());
+
+    draw_messages(f, app, chunks[0]);
+    draw_input(f, app, chunks[1]);
+    draw_status(f, app, chunks[2]);
+
+    // Draw help overlay if in help mode
+    if app.mode == AppMode::Help {
+        draw_help(f);
+    }
+}
+
+/// Draw the messages area.
+fn draw_messages(f: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Conversation ")
+        .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
+
+    let inner = block.inner(area);
+
+    // Collect message lines
+    let mut lines: Vec<Line> = Vec::new();
+
+    for msg in &app.messages {
+        let (prefix, style) = match msg.role {
+            Role::User => ("You: ", Style::default().fg(Color::Green)),
+            Role::Assistant => ("Codi: ", Style::default().fg(Color::Blue)),
+            Role::System => ("System: ", Style::default().fg(Color::Yellow)),
+        };
+
+        // Add prefix line
+        lines.push(Line::from(vec![
+            Span::styled(prefix, style.add_modifier(Modifier::BOLD)),
+        ]));
+
+        // Add content lines with word wrap
+        for line in msg.content.lines() {
+            lines.push(Line::from(Span::raw(format!("  {}", line))));
+        }
+
+        // Add streaming indicator
+        if msg.streaming {
+            lines.push(Line::from(Span::styled(
+                "  ▌",
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+
+        // Add blank line between messages
+        lines.push(Line::from(""));
+    }
+
+    // Apply scroll offset
+    let visible_height = inner.height as usize;
+    let total_lines = lines.len();
+    let scroll_offset = if total_lines > visible_height {
+        let max_offset = total_lines.saturating_sub(visible_height);
+        (app.scroll_offset as usize).min(max_offset)
+    } else {
+        0
+    };
+
+    let visible_lines: Vec<Line> = lines.into_iter().skip(scroll_offset).collect();
+
+    let messages = Paragraph::new(visible_lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+
+    f.render_widget(messages, area);
+}
+
+/// Draw the input area.
+fn draw_input(f: &mut Frame, app: &App, area: Rect) {
+    let (title, border_style) = match app.mode {
+        AppMode::Normal => (" Input (Esc to quit, /help for commands) ", Style::default()),
+        AppMode::Waiting => (" Waiting... (Esc to cancel) ", Style::default().fg(Color::Yellow)),
+        AppMode::Help => (" Help ", Style::default().fg(Color::Cyan)),
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(border_style);
+
+    let input = Paragraph::new(app.input.as_str())
+        .block(block)
+        .style(Style::default());
+
+    f.render_widget(input, area);
+
+    // Show cursor in normal mode
+    if app.mode == AppMode::Normal {
+        f.set_cursor_position((
+            area.x + 1 + app.cursor_pos as u16,
+            area.y + 1,
+        ));
+    }
+}
+
+/// Draw the status bar.
+fn draw_status(f: &mut Frame, app: &App, area: Rect) {
+    let status_text = app.status.as_deref().unwrap_or_else(|| {
+        if app.has_provider() {
+            "Ready"
+        } else {
+            "No provider configured"
+        }
+    });
+
+    let provider_info = if app.has_provider() {
+        // TODO: Show provider/model info
+        ""
+    } else {
+        ""
+    };
+
+    let status = Paragraph::new(Line::from(vec![
+        Span::styled(" ", Style::default()),
+        Span::styled(status_text, Style::default().fg(Color::Gray)),
+        Span::styled(provider_info, Style::default().fg(Color::DarkGray)),
+    ]))
+    .style(Style::default().bg(Color::DarkGray));
+
+    f.render_widget(status, area);
+}
+
+/// Draw the help overlay.
+fn draw_help(f: &mut Frame) {
+    let area = centered_rect(60, 60, f.area());
+
+    let help_text = vec![
+        Line::from(Span::styled(
+            " Codi Commands ",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("/help", Style::default().fg(Color::Yellow)),
+            Span::raw("     - Show this help"),
+        ]),
+        Line::from(vec![
+            Span::styled("/clear", Style::default().fg(Color::Yellow)),
+            Span::raw("    - Clear conversation"),
+        ]),
+        Line::from(vec![
+            Span::styled("/exit", Style::default().fg(Color::Yellow)),
+            Span::raw("     - Exit Codi"),
+        ]),
+        Line::from(vec![
+            Span::styled("/quit", Style::default().fg(Color::Yellow)),
+            Span::raw("     - Exit Codi"),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            " Keyboard Shortcuts ",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::raw("       - Quit / Cancel"),
+        ]),
+        Line::from(vec![
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::raw("     - Send message"),
+        ]),
+        Line::from(vec![
+            Span::styled("Up/Down", Style::default().fg(Color::Yellow)),
+            Span::raw("   - Scroll messages"),
+        ]),
+        Line::from(vec![
+            Span::styled("PgUp/PgDn", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Scroll faster"),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Press Esc or Enter to close",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Help ")
+        .title_style(Style::default().fg(Color::Cyan))
+        .style(Style::default().bg(Color::Black));
+
+    let help = Paragraph::new(help_text).block(block);
+
+    f.render_widget(Clear, area);
+    f.render_widget(help, area);
+}
+
+/// Create a centered rectangle.
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}


### PR DESCRIPTION
## Summary

Implements Phase 6 of the Rust migration: Terminal User Interface using ratatui.

**Dependencies Added:**
- `ratatui` 0.29 - Terminal UI framework
- `crossterm` 0.28 - Cross-platform terminal handling
- `rustyline` 15 - Readline-like input handling

**New Files Created (~500 lines):**
- `src/tui/mod.rs` - Module exports and terminal init/restore
- `src/tui/app.rs` - Application state and main event loop
- `src/tui/events.rs` - Async event handling (keyboard, mouse, resize)
- `src/tui/ui.rs` - UI rendering with message display, input, status bar
- `src/tui/commands.rs` - Slash command handling

**Key Features:**
- Three-pane layout: messages area, input field, status bar
- User/Assistant message display with color coding
- Full text editing: cursor movement, backspace, delete, home/end
- Scroll support for message history (Up/Down, PageUp/PageDown)
- Help overlay with command reference (press /help)
- Basic slash commands: `/help`, `/clear`, `/exit`, `/quit`, `/version`
- Async event loop with tick-based updates
- Graceful terminal restore on exit

**Architecture:**
- `AppMode`: Normal, Waiting, Help states
- `EventHandler`: Async event polling with tokio
- `ChatMessage`: Display-focused message type
- Provider integration ready (awaiting streaming)

## Test plan
- [x] Run `cargo test tui --lib` - 12 tests passing
- [x] Run `cargo test --lib` - 260 total tests passing
- [x] Verify compilation with `cargo check`

## Known Limitations (Future Work)
- Streaming text display not yet implemented
- Provider info not shown in status bar
- No markdown rendering
- No syntax-highlighted diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)