### PR TITLE
fix(bash): increase timeout from 30s to 10 minutes

### DIFF
--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -7,7 +7,7 @@ import type { ToolDefinition } from '../types.js';
 import type { ExecErrorWithOutput } from '../types/extended.js';
 import { getBlockingPatterns } from '../utils/index.js';
 
-const TIMEOUT_MS = 30000; // 30 second timeout
+const TIMEOUT_MS = 600000; // 10 minute timeout (600 seconds for E2E tests)
 const MAX_OUTPUT_LENGTH = 50000; // Truncate output if too long
 
 // Get blocking patterns from unified constants


### PR DESCRIPTION
## Summary
- Updated bash command timeout from 30 seconds to 10 minutes (600,000ms)
- Provides adequate time for E2E tests and long-running commands
- Addresses timeouts when running `cargo test` and other heavy test commands

## Rationale
Previous 30-second timeout was too short for running E2E tests like the gitgrip project's end-to-end tests. Increasing to 10 minutes gives sufficient time for comprehensive test suites while still preventing hanging commands from running indefinitely.

## Testing
- ✅ Build passes (tsc)
- ✅ All tests pass (103 test files, 2201 tests passed)
- Manual testing with long-running commands confirms new timeout works as expected.

Wingman: Codi <codi@layne.pro>