### PR TITLE
fix: batch config wiring quick wins (#262-#266)

### DIFF
--- a/codi-rs/src/main.rs
+++ b/codi-rs/src/main.rs
@@ -12,7 +12,7 @@ use codi::agent::AgentConfig;
 use codi::config::{self, CliOptions};
 use codi::providers::{create_provider_from_config, ProviderType};
 use codi::tools::ToolRegistry;
-use codi::tui::{App, run as run_tui};
+use codi::tui::{App, build_system_prompt_from_config, run as run_tui};
 
 /// Codi version string.
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -459,13 +459,14 @@ async fn handle_prompt(
         extract_tools_from_text: config.extract_tools_from_text,
         auto_approve_all: auto_approve,
         auto_approve_tools: config.auto_approve.clone(),
+        dangerous_patterns: config.dangerous_patterns.clone(),
     };
 
     // Create and run agent
     let mut agent = codi::agent::Agent::new(codi::agent::AgentOptions {
         provider,
         tool_registry: registry,
-        system_prompt: Some("You are Codi, a helpful AI coding assistant.".to_string()),
+        system_prompt: Some(build_system_prompt_from_config(Some(config))),
         config: agent_config,
         callbacks: codi::agent::AgentCallbacks::default(),
     });

--- a/codi-rs/src/orchestrate/child_agent.rs
+++ b/codi-rs/src/orchestrate/child_agent.rs
@@ -241,6 +241,7 @@ impl ChildAgent {
             extract_tools_from_text: true,
             auto_approve_all: false,
             auto_approve_tools: self.auto_approve.clone(),
+            dangerous_patterns: Vec::new(),
         };
 
         let mut agent = Agent::new(AgentOptions {

--- a/codi-rs/src/tui/mod.rs
+++ b/codi-rs/src/tui/mod.rs
@@ -41,7 +41,7 @@ pub mod events;
 pub mod streaming;
 pub mod ui;
 
-pub use app::{App, AppMode, Message as ChatMessage};
+pub use app::{App, AppMode, Message as ChatMessage, build_system_prompt_from_config};
 pub use events::{Event, EventHandler};
 pub use streaming::{MarkdownStreamCollector, StreamController, StreamState, StreamStatus};
 


### PR DESCRIPTION
## Summary

Five quick fixes to close gaps left after PR #261's config wiring:

- **#262** — Deprecate `with_provider()`/`with_provider_and_path()` constructors that bypass config. Added `#[deprecated]` attributes pointing to the correct `with_project_path()` + `set_config()` + `set_provider()` pattern.
- **#264** — Wire `on_compaction` callback so the TUI displays "Compacting context..." / "Context compacted" status messages. Added `Compaction(bool)` variant to `AppEvent`.
- **#266** — Extract `build_system_prompt_from_config()` as a standalone public function and use it in `-P` non-interactive mode, so config-driven `systemPromptAdditions` and `projectContext` are applied consistently.
- **#263** — Wire `dangerousPatterns` config through to tool confirmation. Added `dangerous_patterns` field to `AgentConfig`, `matches_dangerous_pattern()` method, and unified `maybe_confirm()` that checks both built-in destructive tools and custom patterns in a single pass.
- **#265** — Cache `running_char_count` on `AgentState` to avoid re-serializing all message JSON on every iteration of the agent loop. Incremented on each message push, recalculated after compaction.

## Files changed (6)

| File | Fixes |
|------|-------|
| `codi-rs/src/tui/app.rs` | #262, #264, #266, #263 |
| `codi-rs/src/tui/mod.rs` | #266 |
| `codi-rs/src/main.rs` | #266, #263 |
| `codi-rs/src/agent/types.rs` | #263, #265 |
| `codi-rs/src/agent/mod.rs` | #263, #265 |
| `codi-rs/src/orchestrate/child_agent.rs` | #263 |

## Test plan

- [x] `cargo build` — clean, zero warnings
- [x] `cargo test` — 463 tests pass (7 new)
- [x] New tests: `test_dangerous_pattern_match`, `test_dangerous_pattern_empty`, `test_dangerous_pattern_invalid_regex_skipped`, `test_agent_state_default_running_char_count`, `test_build_system_prompt_from_config_none`, `test_build_system_prompt_from_config_with_additions`, `test_app_event_compaction_variant`

## Review notes

- `maybe_confirm()` replaces the old `should_confirm()` + `confirm_tool()` two-method pattern to avoid double-serializing tool input JSON
- Invalid regex patterns in `dangerousPatterns` config emit a `tracing::warn!` rather than silently skipping
- `messages_mut()` is a known escape hatch that bypasses `running_char_count` — no current callers, but noted for future awareness

🤖 Generated with [Claude Code](https://claude.com/claude-code)