### PR TITLE
feat: add tui cancel + windows tests

### DIFF
--- a/codi-rs/docs/ROADMAP.md
+++ b/codi-rs/docs/ROADMAP.md
@@ -9,10 +9,10 @@ This roadmap focuses on the Rust CLI (`codi-rs`) and its TUI/orchestration stack
 
 ## P0: Stability and Cross-Platform Foundations
 
-1) Cross-platform IPC for multi-agent
-- Replace Unix domain sockets with an IPC abstraction.
-- Implement Windows named pipes (or a transport-agnostic layer).
-- Ensure commander/worker handshake is deterministic with explicit timeouts.
+1) Cross-platform IPC for multi-agent (complete)
+- Transport abstraction with Windows named pipes.
+- Deterministic commander/worker handshake with explicit timeouts.
+- Windows IPC tests for roundtrip + handshake/permission flows.
 
 2) Cancellation and lifecycle correctness
 - Wire the TUI cancel flow to actual worker cancellation.

--- a/codi-rs/src/config/loader.rs
+++ b/codi-rs/src/config/loader.rs
@@ -170,6 +170,14 @@ mod tests {
         assert!(dir.ends_with(".codi"));
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn test_global_config_dir_windows() {
+        let home = dirs::home_dir().expect("home dir");
+        let expected = home.join(GLOBAL_CONFIG_DIR);
+        assert_eq!(get_global_config_dir().unwrap(), expected);
+    }
+
     #[test]
     fn test_load_workspace_config_not_found() {
         let temp = TempDir::new().unwrap();

--- a/codi-rs/src/orchestrate/ipc/transport.rs
+++ b/codi-rs/src/orchestrate/ipc/transport.rs
@@ -8,10 +8,11 @@ use std::path::Path;
 
 use tokio::io::{AsyncRead, AsyncWrite};
 
-pub trait IpcStreamTrait: AsyncRead + AsyncWrite {}
-impl<T: AsyncRead + AsyncWrite> IpcStreamTrait for T {}
+pub trait IpcIo: AsyncRead + AsyncWrite + Unpin + Send {}
 
-pub type IpcStream = Box<dyn IpcStreamTrait + Unpin + Send>;
+impl<T> IpcIo for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
+
+pub type IpcStream = Box<dyn IpcIo>;
 
 #[cfg(unix)]
 use tokio::net::UnixListener;

--- a/codi-rs/src/tools/handlers/bash.rs
+++ b/codi-rs/src/tools/handlers/bash.rs
@@ -276,12 +276,44 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    fn echo_command() -> &'static str {
+        if cfg!(windows) {
+            "echo hello world"
+        } else {
+            "echo 'hello world'"
+        }
+    }
+
+    fn list_command() -> &'static str {
+        if cfg!(windows) {
+            "dir /B"
+        } else {
+            "ls"
+        }
+    }
+
+    fn stderr_command() -> &'static str {
+        if cfg!(windows) {
+            "echo error 1>&2"
+        } else {
+            "echo 'error' >&2"
+        }
+    }
+
+    fn timeout_command() -> &'static str {
+        if cfg!(windows) {
+            "ping -n 5 127.0.0.1 > NUL"
+        } else {
+            "sleep 10"
+        }
+    }
+
     #[tokio::test]
     async fn test_bash_echo() {
         let handler = BashHandler;
         let result = handler
             .execute(serde_json::json!({
-                "command": "echo 'hello world'"
+                "command": echo_command()
             }))
             .await
             .unwrap();
@@ -298,7 +330,7 @@ mod tests {
         let handler = BashHandler;
         let result = handler
             .execute(serde_json::json!({
-                "command": "ls",
+                "command": list_command(),
                 "cwd": temp.path().to_str().unwrap()
             }))
             .await
@@ -327,7 +359,7 @@ mod tests {
         let handler = BashHandler;
         let result = handler
             .execute(serde_json::json!({
-                "command": "echo 'error' >&2"
+                "command": stderr_command()
             }))
             .await
             .unwrap();
@@ -366,7 +398,7 @@ mod tests {
         let handler = BashHandler;
         let result = handler
             .execute(serde_json::json!({
-                "command": "sleep 10",
+                "command": timeout_command(),
                 "timeout": 100  // 100ms timeout
             }))
             .await

--- a/codi-rs/src/tui/terminal_ui.rs
+++ b/codi-rs/src/tui/terminal_ui.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crossterm::{
-    style::{Color, Print, ResetColor, SetForegroundColor},
+    style::{Color, Print, ResetColor, SetForegroundColor, Stylize},
     ExecutableCommand,
 };
 


### PR DESCRIPTION
## Summary
- add cancelable agent chat in the TUI with proper cancellation signaling
- add Windows-aware bash tool tests and a Windows config loader check
- update codi-rs roadmap IPC status and fix IPC stream trait object

## Testing
- cargo test (codi-rs)