### PR TITLE
fix: isolate tests from workspace CODI_HOME env var

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,13 @@
+// Copyright 2026 Layne Penney
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Vitest global setup.
+ *
+ * Removes workspace-specific environment variables that interfere with
+ * test isolation.  CODI_HOME is set by envsetup.sh to point at the
+ * workspace .codi directory, but tests expect the default home-relative
+ * path (~/.codi).
+ */
+
+delete process.env.CODI_HOME;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
+    setupFiles: ['tests/setup.ts'],
     include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
     // Default timeout (increased for e2e tests in their own files)
     testTimeout: 10000,


### PR DESCRIPTION
## Summary
- Add vitest setup file (`tests/setup.ts`) that deletes `CODI_HOME` from `process.env` before tests run
- The workspace `envsetup.sh` sets `CODI_HOME` to the gripspace `.codi` directory, which leaked into tests and broke path isolation for unit tests (session, memory, model-map) and E2E tests (debug-bridge, session-commands)

## Test plan
- [x] All 2203 tests pass (0 failures), previously 22 failures across 5 test files
- [x] Full suite run twice to confirm no flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)